### PR TITLE
chore(rust): bump starknet, cainome, rust toolchain

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -3401,9 +3401,9 @@ dependencies = [
 
 [[package]]
 name = "cainome"
-version = "0.8.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dd7cc8b7674f2285ea36cdf883c14f7c6bfedf12a9643d77dd618e43d34345"
+checksum = "f296568cda6f1f4934270a321151f9f51afa737450f67ef13a8534f2bd9afdac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3418,7 +3418,7 @@ dependencies = [
  "convert_case 0.8.0",
  "serde",
  "serde_json",
- "starknet 0.15.1",
+ "starknet",
  "starknet-types-core",
  "thiserror 2.0.18",
  "tracing",
@@ -3428,14 +3428,14 @@ dependencies = [
 
 [[package]]
 name = "cainome-cairo-serde"
-version = "0.2.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da490d99e84c141e9f5646965de176d6fbfcc7a525f17b6b08e208cd65e6fe35"
+checksum = "95ae2d4c21db23c7730a85187c2e9d73fe00c123171839185fb13f31550f3240"
 dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "serde_with",
- "starknet 0.15.1",
+ "starknet",
  "thiserror 2.0.18",
 ]
 
@@ -3453,23 +3453,23 @@ dependencies = [
 
 [[package]]
 name = "cainome-parser"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feaf4e3cba66ccc85bca9726e09ffd69d3b1be37f1305ed59e1b1d5a6e86fabc"
+checksum = "4ffdbc6abfba9c7e91beb87fe7561f097d9f7bbda45c6ff74be3a9ff3f1a0124"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case 0.8.0",
  "quote 1.0.45",
  "serde_json",
- "starknet 0.14.0",
+ "starknet",
  "syn 2.0.117",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cainome-rs"
-version = "0.3.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b24e87fcf544b3112f70e36eb560c78c0f7e18ca5d6a1483fdf7b05e7e8302e9"
+checksum = "93aa5c33e66b58ff6723d3e43e60fe163ac20719ea89fce921096e654b15bcd6"
 dependencies = [
  "anyhow",
  "cainome-cairo-serde",
@@ -3479,16 +3479,16 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.45",
  "serde_json",
- "starknet 0.15.1",
+ "starknet",
  "syn 2.0.117",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cainome-rs-macro"
-version = "0.3.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919354b1142e3ca398313b842a5f95b081b0261270164a8fcdf13c8c633193fd"
+checksum = "9d679cd9a88b9d412ed4ed30264b80f1bec6c1aa9656e238f06be560ddebb652"
 dependencies = [
  "anyhow",
  "cainome-cairo-serde",
@@ -3498,9 +3498,9 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.45",
  "serde_json",
- "starknet 0.14.0",
+ "starknet",
  "syn 2.0.117",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8683,7 +8683,7 @@ dependencies = [
  "time",
  "tokio",
  "tonic 0.12.3",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
  "tracing-futures",
  "url",
@@ -9076,7 +9076,7 @@ dependencies = [
  "reqwest-utils",
  "serde",
  "serde_json",
- "starknet 0.15.1",
+ "starknet",
  "thiserror 1.0.63",
  "tokio",
  "tracing",
@@ -9958,11 +9958,13 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-crypto"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc2a4da0d9e52ccfe6306801a112e81a8fc0c76aa3e4449fefeda7fef72bb34"
+checksum = "58b1a1c1102a5a7fbbda117b79fb3a01e033459c738a3c1642269603484fd1c1"
 dependencies = [
  "lambdaworks-math",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "sha2 0.10.8",
  "sha3",
@@ -9970,10 +9972,14 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-math"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1bd2632acbd9957afc5aeec07ad39f078ae38656654043bf16e046fa2730e23"
+checksum = "018a95aa873eb49896a858dee0d925c33f3978d073c64b08dd4f2c9b35a017c6"
 dependencies = [
+ "getrandom 0.2.15",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "rand 0.8.5",
  "serde",
  "serde_json",
 ]
@@ -12896,7 +12902,7 @@ dependencies = [
  "tokio",
  "tokio-metrics",
  "tokio-test",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-http",
  "tracing",
  "tracing-futures",
@@ -13362,7 +13368,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "starknet 0.15.1",
+ "starknet",
  "tempfile",
  "tokio",
  "toml_edit 0.19.15",
@@ -14960,12 +14966,6 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
-name = "size-of"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e36eca171fddeda53901b0a436573b3f2391eaa9189d439b2bd8ea8cebd7e3"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -19174,124 +19174,55 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starknet"
-version = "0.14.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e2e53e7705c9a9aad7f118a4bac7386afeb8db272b3eb445a464ca4c3dfee5"
+checksum = "f5ed01c14136e56dcdf21385d20c4a6fdd3509947cb56cca45fc765ef5809add"
 dependencies = [
- "starknet-accounts 0.13.0",
- "starknet-contract 0.13.0",
- "starknet-core 0.13.0",
+ "starknet-accounts",
+ "starknet-contract",
+ "starknet-core",
  "starknet-core-derive",
  "starknet-crypto",
  "starknet-macros",
- "starknet-providers 0.13.0",
- "starknet-signers 0.11.0",
-]
-
-[[package]]
-name = "starknet"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ec983c56ce05b2d7679fa860b37b2ade21004c343ff49374a591b40ee8ee1d"
-dependencies = [
- "starknet-accounts 0.14.0",
- "starknet-contract 0.14.0",
- "starknet-core 0.14.0",
- "starknet-core-derive",
- "starknet-crypto",
- "starknet-macros",
- "starknet-providers 0.14.1",
- "starknet-signers 0.12.0",
+ "starknet-providers",
+ "starknet-signers",
 ]
 
 [[package]]
 name = "starknet-accounts"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca52534db01eda3bf3250f398bd4597aed3856d0d17d84070efbc7919abad71"
+checksum = "4f7c118729bcdcfa1610844047cbdb23090fb1d4172a36bb97a663be8d022d1a"
 dependencies = [
  "async-trait",
  "auto_impl 1.2.0",
- "starknet-core 0.13.0",
+ "starknet-core",
  "starknet-crypto",
- "starknet-providers 0.13.0",
- "starknet-signers 0.11.0",
- "thiserror 1.0.63",
-]
-
-[[package]]
-name = "starknet-accounts"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7adf55fa08ffed413614df3171632e45dcba72cc53706b147ba08e5b7b4e4fb"
-dependencies = [
- "async-trait",
- "auto_impl 1.2.0",
- "starknet-core 0.14.0",
- "starknet-crypto",
- "starknet-providers 0.14.1",
- "starknet-signers 0.12.0",
+ "starknet-providers",
+ "starknet-signers",
  "thiserror 1.0.63",
 ]
 
 [[package]]
 name = "starknet-contract"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d8d5a5306527eedcb4bd70afecfc6824add631a08eac8fd1cf9c2bdfd21e77"
+checksum = "ccb64331b72caf51c0d8b684b62012f9a771015b4cf5e52cba9bf61be8384ad3"
 dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-accounts 0.13.0",
- "starknet-core 0.13.0",
- "starknet-providers 0.13.0",
- "thiserror 1.0.63",
-]
-
-[[package]]
-name = "starknet-contract"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72746fa496e352ef16b4a8fd11e415ada6b7b5a9107fc6e845eeb921b8bb2a69"
-dependencies = [
- "serde",
- "serde_json",
- "serde_with",
- "starknet-accounts 0.14.0",
- "starknet-core 0.14.0",
- "starknet-providers 0.14.1",
+ "starknet-accounts",
+ "starknet-core",
+ "starknet-providers",
  "thiserror 1.0.63",
 ]
 
 [[package]]
 name = "starknet-core"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a16799e4a75173839d868a1a48ff5d3e10456febd4dec91b04ba6521741d5"
-dependencies = [
- "base64 0.21.7",
- "crypto-bigint 0.5.5",
- "flate2",
- "foldhash 0.1.5",
- "hex 0.4.3",
- "indexmap 2.12.0",
- "num-traits",
- "serde",
- "serde_json",
- "serde_json_pythonic",
- "serde_with",
- "sha3",
- "starknet-core-derive",
- "starknet-crypto",
- "starknet-types-core",
-]
-
-[[package]]
-name = "starknet-core"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2091a08ebfc65c5a6b8bd2c66e32780739854b813af0b4348b6dbf3a887865"
+checksum = "efb7212226769766c1c7d79b70f9242ffbd213290a41604ecc7e78faa0ed0deb"
 dependencies = [
  "base64 0.21.7",
  "crypto-bigint 0.5.5",
@@ -19323,9 +19254,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039a3bad70806b494c9e6b21c5238a6c8a373d66a26071859deb0ccca6f93634"
+checksum = "1004a16c25dc6113c19d4f9d0c19ff97d85804829894bba22c0d0e9e7b249812"
 dependencies = [
  "crypto-bigint 0.5.5",
  "hex 0.4.3",
@@ -19342,49 +19273,28 @@ dependencies = [
 
 [[package]]
 name = "starknet-curve"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcde6bd74269b8161948190ace6cf069ef20ac6e79cd2ba09b320efa7500b6de"
+checksum = "22c898ae81b6409532374cf237f1bd752d068b96c6ad500af9ebbd0d9bb712f6"
 dependencies = [
  "starknet-types-core",
 ]
 
 [[package]]
 name = "starknet-macros"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dd27bb42d53bd7948a32d4a88c04e799bfcc011b87448756bb0643e6ec0e6d"
+checksum = "6d59e1eb22f4366385b132ba7016faa5a6457f1f23f896f737a06da626455e7b"
 dependencies = [
- "starknet-core 0.14.0",
+ "starknet-core",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "starknet-providers"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74c3850a661fa1ffd3c3e2cb9db6e28c94ab9aaaa0496503014a814f09cd455"
-dependencies = [
- "async-trait",
- "auto_impl 1.2.0",
- "ethereum-types 0.14.1",
- "flate2",
- "getrandom 0.2.15",
- "log",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "serde_with",
- "starknet-core 0.13.0",
- "thiserror 1.0.63",
- "url",
-]
-
-[[package]]
-name = "starknet-providers"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce77bf215b70673264bc875d59c45fb7da500e7e6f71d2608ad25a1f7280671"
+checksum = "15fc3d94cc008cea64e291b261e8349065424ee7491e5dd0fa9bd688818bece1"
 dependencies = [
  "async-trait",
  "auto_impl 1.2.0",
@@ -19396,16 +19306,16 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-core 0.14.0",
+ "starknet-core",
  "thiserror 1.0.63",
  "url",
 ]
 
 [[package]]
 name = "starknet-signers"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aeca13b8c61165b69d4775880d74ff9bbb9bafa36a297899e0f160619631b3"
+checksum = "d839b06d899ef3a0de11b1e9a91a14c118b1ed36830ec8e59d9fbc9a1e51976b"
 dependencies = [
  "async-trait",
  "auto_impl 1.2.0",
@@ -19413,41 +19323,26 @@ dependencies = [
  "eth-keystore",
  "getrandom 0.2.15",
  "rand 0.8.5",
- "starknet-core 0.13.0",
- "starknet-crypto",
- "thiserror 1.0.63",
-]
-
-[[package]]
-name = "starknet-signers"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd831176f8a217694895fd69be17f985e5e28f00bc8044eb54b55656f3a7f1"
-dependencies = [
- "async-trait",
- "auto_impl 1.2.0",
- "crypto-bigint 0.5.5",
- "eth-keystore",
- "getrandom 0.2.15",
- "rand 0.8.5",
- "starknet-core 0.14.0",
+ "starknet-core",
  "starknet-crypto",
  "thiserror 1.0.63",
 ]
 
 [[package]]
 name = "starknet-types-core"
-version = "0.1.8"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4037bcb26ce7c508448d221e570d075196fd4f6912ae6380981098937af9522a"
+checksum = "90d23b1bc014ee4cce40056ab3114bcbcdc2dbc1e845bbfb1f8bd0bab63507d4"
 dependencies = [
+ "blake2",
+ "digest 0.10.7",
  "lambdaworks-crypto",
  "lambdaworks-math",
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
+ "rand 0.9.2",
  "serde",
- "size-of",
  "zeroize",
 ]
 
@@ -21193,7 +21088,7 @@ dependencies = [
  "thiserror 1.0.63",
  "tokio",
  "tokio-test",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
  "tracing-futures",
  "tracing-test",

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -62,7 +62,7 @@ borsh = { version = "1.5", features = ["derive"] }
 bs58 = "0.5.0"
 bytes = "1"
 byteorder = "1.5.0"
-cainome = { version = "0.8.0", features = ["abigen-rs"] }
+cainome = { version = "0.10.1", features = ["abigen-rs"] }
 cargo_metadata = "0.22.0"
 clap = "4"
 chrono = "*"
@@ -176,7 +176,7 @@ solana-stake-interface = "1.2"
 solana-system-interface = { version = "2.0", features = ["bincode"] }
 solana-transaction-status = "3.0"
 solana-vote-interface = "3.0"
-starknet = "0.15.0"
+starknet = "0.17.0"
 static_assertions = "1.1"
 strum = "0.26.2"
 strum_macros = "0.26.2"

--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -37,6 +37,9 @@ impl OpQueue {
     }
 
     /// Pop an element from the queue and update metrics
+    // rustc >= 1.91 flags this unused method; introduced by the dango-side
+    // toolchain bump, not an upstream problem.
+    #[allow(dead_code)]
     #[instrument(skip(self), ret, fields(queue_label=%self.queue_metrics_label), level = "trace")]
     pub async fn pop(&mut self) -> Option<QueueOperation> {
         let pop_attempt = self.pop_many(1).await;

--- a/rust/main/chains/hyperlane-aleo/src/application.rs
+++ b/rust/main/chains/hyperlane-aleo/src/application.rs
@@ -44,6 +44,8 @@ impl AleoApplicationOperationVerifier {
         // Aleo only supports messages bodies that are a multiple of 16 bytes, there are a couple of exceptions to this
         // See the contract implementation for reference: https://github.com/hyperlane-xyz/hyperlane-aleo/blob/main/mailbox/src/main.leo#L258
         let body_bytes = message.body.len();
+        // clippy >= 1.89 wants `is_multiple_of`; keep upstream expression unchanged.
+        #[allow(clippy::manual_is_multiple_of)]
         if (body_bytes % 16 != 0 && body_bytes != 129 && body_bytes != 72 && body_bytes != 80)
             || body_bytes > 256
         {

--- a/rust/main/chains/hyperlane-cosmos/src/cw/payloads/general.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/cw/payloads/general.rs
@@ -1,3 +1,7 @@
+// rustc >= 1.90 no longer counts derive(Deserialize) as construction; these
+// types mirror the CosmWasm API shape.
+#![allow(dead_code)]
+
 use cometbft::abci::v0_34;
 use cometbft::abci::v0_37;
 use serde::{Deserialize, Serialize};

--- a/rust/main/chains/hyperlane-cosmos/src/cw/payloads/ism_routes.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/cw/payloads/ism_routes.rs
@@ -1,3 +1,7 @@
+// rustc >= 1.90 no longer counts derive(Deserialize) as construction; these
+// types mirror the CosmWasm API shape.
+#![allow(dead_code)]
+
 use super::general::EmptyStruct;
 use serde::{Deserialize, Serialize};
 

--- a/rust/main/chains/hyperlane-cosmos/src/cw/payloads/mailbox.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/cw/payloads/mailbox.rs
@@ -1,3 +1,7 @@
+// rustc >= 1.90 no longer counts derive(Deserialize) as construction; these
+// types mirror the CosmWasm API shape.
+#![allow(dead_code)]
+
 use serde::{Deserialize, Serialize};
 
 use super::general::EmptyStruct;

--- a/rust/main/chains/hyperlane-cosmos/src/cw/payloads/validator_announce.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/cw/payloads/validator_announce.rs
@@ -1,3 +1,7 @@
+// rustc >= 1.90 no longer counts derive(Deserialize) as construction; these
+// types mirror the CosmWasm API shape.
+#![allow(dead_code)]
+
 use serde::{Deserialize, Serialize};
 
 use super::general::EmptyStruct;

--- a/rust/main/chains/hyperlane-dango/src/types/provider.rs
+++ b/rust/main/chains/hyperlane-dango/src/types/provider.rs
@@ -202,9 +202,9 @@ impl DangoProvider {
         // Currently we support only None reorg period
 
         if let ReorgPeriod::None = reorg_period {
-            return Ok(());
+            Ok(())
         } else {
-            return Err(DangoError::InvalidReorgPeriod(reorg_period.clone()).into());
+            Err(DangoError::InvalidReorgPeriod(reorg_period.clone()).into())
         }
 
         // let block_height = match reorg_period {

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
@@ -347,6 +347,9 @@ where
         .await
     }
 
+    // rustc >= 1.91 flags this unused private helper; introduced by the dango-side
+    // toolchain bump, not an upstream problem.
+    #[allow(dead_code)]
     #[instrument(err, skip(self))]
     async fn get_storage_at(&self, address: H256, location: H256) -> ChainResult<H256> {
         let storage = self

--- a/rust/main/chains/hyperlane-starknet/src/provider/client.rs
+++ b/rust/main/chains/hyperlane-starknet/src/provider/client.rs
@@ -7,7 +7,7 @@ use hyperlane_core::{
 };
 use hyperlane_metric::prometheus_metric::{ChainInfo, PrometheusClientMetrics};
 use starknet::core::types::{
-    BlockId, BlockTag, Felt, FunctionCall, InvokeTransaction, MaybePendingBlockWithTxHashes,
+    BlockId, BlockTag, Felt, FunctionCall, InvokeTransaction, MaybePreConfirmedBlockWithTxHashes,
     Transaction, TransactionReceipt,
 };
 use starknet::macros::selector;
@@ -78,13 +78,13 @@ impl HyperlaneChain for StarknetProvider {
 impl HyperlaneProvider for StarknetProvider {
     #[instrument(err, skip(self))]
     async fn get_block_by_height(&self, height: u64) -> ChainResult<BlockInfo> {
-        let block: MaybePendingBlockWithTxHashes = self
+        let block: MaybePreConfirmedBlockWithTxHashes = self
             .rpc_client()
             .get_block_with_tx_hashes(BlockId::Number(height))
             .await
             .map_err(Into::<HyperlaneStarknetError>::into)?;
         match block {
-            MaybePendingBlockWithTxHashes::Block(b) => Ok(BlockInfo {
+            MaybePreConfirmedBlockWithTxHashes::Block(b) => Ok(BlockInfo {
                 hash: H256::from_slice(b.block_hash.to_bytes_be().as_slice()),
                 timestamp: b.timestamp,
                 number: b.block_number,

--- a/rust/main/chains/hyperlane-starknet/src/provider/fallback.rs
+++ b/rust/main/chains/hyperlane-starknet/src/provider/fallback.rs
@@ -84,7 +84,7 @@ impl JsonRpcTransport for FallbackHttpTransport {
     ) -> Result<JsonRpcResponse<R>, Self::Error>
     where
         P: Serialize + Send,
-        R: DeserializeOwned,
+        R: DeserializeOwned + Send,
     {
         let params_json = serde_json::to_value(params).map_err(Self::Error::Json)?;
         let mut errors = vec![];

--- a/rust/main/chains/hyperlane-starknet/src/provider/metric.rs
+++ b/rust/main/chains/hyperlane-starknet/src/provider/metric.rs
@@ -91,7 +91,7 @@ impl JsonRpcTransport for MetricProvider {
     ) -> Result<JsonRpcResponse<R>, Self::Error>
     where
         P: Serialize + Send,
-        R: DeserializeOwned,
+        R: DeserializeOwned + Send,
     {
         let start = Instant::now();
         let params_json = serde_json::to_value(params).map_err(Self::Error::Json)?;

--- a/rust/main/chains/hyperlane-starknet/src/utils.rs
+++ b/rust/main/chains/hyperlane-starknet/src/utils.rs
@@ -8,7 +8,6 @@ use hyperlane_core::{
     ChainCommunicationError, ChainResult, HyperlaneMessage, ModuleType, ReorgPeriod, TxOutcome,
 };
 use starknet::accounts::ExecutionV3;
-use starknet::core::types::ReceiptBlock;
 use starknet::{
     accounts::SingleOwnerAccount,
     core::{
@@ -52,7 +51,7 @@ pub async fn get_transaction_receipt(
                     .await
                     .map_err(HyperlaneStarknetError::from)?;
 
-                if tx.block == ReceiptBlock::Pending {
+                if tx.block.is_pre_confirmed() {
                     return Err(HyperlaneStarknetError::PendingBlock.into());
                 }
 

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -1569,6 +1569,8 @@ impl ChainConf {
         cfg
     }
 
+    // rustc >= 1.90 wants `ContractLocator<'_>` here; keep upstream signature.
+    #[allow(mismatched_lifetime_syntaxes)]
     fn locator(&self, address: H256) -> ContractLocator {
         ContractLocator {
             domain: &self.domain,

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -707,10 +707,9 @@ impl ChainConf {
 
                 Ok(Box::new(indexer) as Box<dyn SequenceAwareIndexer<H256>>)
             }
-            ChainConnectionConf::Dango(confg) => {
-                let indexer = Box::new(h_dango::contracts::DangoMailbox::new(
-                    confg, &locator, None,
-                )?);
+            ChainConnectionConf::Dango(conf) => {
+                let indexer =
+                    Box::new(h_dango::contracts::DangoMailbox::new(conf, &locator, None)?);
                 Ok(indexer as Box<dyn SequenceAwareIndexer<H256>>)
             }
         }

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -273,7 +273,7 @@ fn build_dango_connection_conf(
         .parse_string()
         .end()
         .or_else(|| {
-            local_err.push(&chain.cwp + "chain_id", eyre!("Missing chain_id"));
+            local_err.push((&chain.cwp).add("chain_id"), eyre!("Missing chain_id"));
             None
         });
 
@@ -311,7 +311,7 @@ fn build_dango_connection_conf(
         .parse_f64()
         .end()
         .or_else(|| {
-            local_err.push(&chain.cwp + "gas_scale", eyre!("Missing gas_scale"));
+            local_err.push((&chain.cwp).add("gas_scale"), eyre!("Missing gas_scale"));
             None
         });
 
@@ -322,7 +322,7 @@ fn build_dango_connection_conf(
         .end()
         .or_else(|| {
             local_err.push(
-                &chain.cwp + "flat_gas_increase",
+                (&chain.cwp).add("flat_gas_increase"),
                 eyre!("Missing flat_gas_increase"),
             );
             None
@@ -335,7 +335,7 @@ fn build_dango_connection_conf(
         .end()
         .or_else(|| {
             local_err.push(
-                &chain.cwp + "search_retry_attempts",
+                (&chain.cwp).add("search_retry_attempts"),
                 eyre!("Missing search_retry_attempts"),
             );
             None
@@ -746,7 +746,7 @@ fn parse_duration(
         .parse_string()
         .end()
         .or_else(|| {
-            local_err.push(&chain.cwp + key, eyre!("Missing {key}"));
+            local_err.push((&chain.cwp).add(key), eyre!("Missing {key}"));
             None
         })
         .and_then(|str| {
@@ -754,7 +754,7 @@ fn parse_duration(
                 .map(Some)
                 .unwrap_or_else(|e| {
                     local_err.push(
-                        &chain.cwp + key,
+                        (&chain.cwp).add(key),
                         eyre!("Invalid search sleep duration: {e}"),
                     );
                     None

--- a/rust/main/hyperlane-core/src/matching_list.rs
+++ b/rust/main/hyperlane-core/src/matching_list.rs
@@ -37,6 +37,9 @@ pub enum Filter<T> {
     Enumerated(Vec<T>),
 }
 
+// clippy >= 1.90 wants this derived; keep the manual impl to avoid churning
+// upstream code (`derive(Default)` requires a `#[default]` variant attribute).
+#[allow(clippy::derivable_impls)]
 impl<T> Default for Filter<T> {
     fn default() -> Self {
         Self::Wildcard

--- a/rust/main/hyperlane-metric/src/utils.rs
+++ b/rust/main/hyperlane-metric/src/utils.rs
@@ -16,6 +16,9 @@ pub fn url_to_host_info(url: &Url) -> Option<String> {
     }
 }
 
+// Writing into a String is infallible; clippy >= 1.89 flags the `unwrap` under
+// the crate-level `deny(clippy::unwrap_used)`, clippy 1.88 does not.
+#[allow(clippy::unwrap_used)]
 fn schemed_url_to_host_info(url: &Url) -> Option<String> {
     if let Some(host) = url.host_str() {
         let mut s = String::new();

--- a/rust/main/lander/src/dispatcher/stages/finality_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage.rs
@@ -247,6 +247,8 @@ impl FinalityStage {
                 .flatten()
             {
                 // update payload status in db
+                // clippy >= 1.90 suggests `std::slice::from_ref`; keep upstream expression.
+                #[allow(clippy::cloned_ref_to_slice_refs)]
                 state
                     .update_status_for_payloads(&[payload.clone()], PayloadStatus::ReadyToSubmit)
                     .await;

--- a/rust/main/rust-toolchain
+++ b/rust/main/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.91.0"
 profile = "default"


### PR DESCRIPTION
- Bump starknet 0.15 -> 0.17 and cainome 0.8 -> 0.10.1. This removes the abandoned `size-of 0.1.5` crate from the dependency tree, which prevented us from bumping rust toolchain to >= 1.90.
- Bump Rust toolchain to 1.91 (the lowest version at which dango compiles).
- Skip several lint sites introduced between 1.88 (what upstream hyperlane-xyz/hyperlane-monorepo uses) and 1.91 (what our fork uses). These lint sites are in the original hyperlane code, not dango-added code, so we don't touch them.
