### PR TITLE
chore(dango): bump left-curve deps to 11bdf76

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.11.2"
+version = "3.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7926860314cbe2fb5d1f13731e387ab43bd32bca224e82e6e2db85de0a3dba49"
+checksum = "48e2faa3e7418ed780cca54829d32782a4008a077230f67457caa063415e99c2"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -140,7 +140,7 @@ dependencies = [
  "derive_more 2.0.1",
  "encoding_rs",
  "flate2",
- "foldhash 0.1.5",
+ "foldhash 0.2.0",
  "futures-core",
  "h2 0.3.27",
  "http 0.2.12",
@@ -152,8 +152,8 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.2",
- "sha1",
+ "rand 0.10.2",
+ "sha1 0.11.0",
  "smallvec",
  "tokio",
  "tokio-util",
@@ -390,6 +390,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-ws"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf53c3cdd63dd6f289980b430238f9a2f6d19f8bce8e418272e08d3da43f0f"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-web",
+ "bytestring",
+ "futures-core",
+ "futures-sink",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "actix_derive"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,7 +443,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array 0.14.7",
 ]
 
@@ -439,7 +455,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.13",
 ]
 
 [[package]]
@@ -639,9 +655,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e15860af634cad451f598712c24ca7fd9b45d84fff68ab8d4967567fa996c64"
+checksum = "d8010fc7e9e8643ef4e758cdccf3eef26734594aedf88a9d5ed35e51837d42ef"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -677,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6440213a22df93a87ed512d2f668e7dc1d62a05642d107f82d61edc9e12370"
+checksum = "e3d64da86c616b5092ea64eea648f311bbd58630a0b384c42d699175d6f9122b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -704,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d0bea09287942405c4f9d2a4f22d1e07611c2dbd9d5bf94b75366340f9e6e0"
+checksum = "8fd98696ca3617d3a9ba1a6f2011880cbfd5618228dab6400c9f8bca457859a8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -718,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69af404f1d00ddb42f2419788fa87746a4cd13bab271916d7726fda6c792d94"
+checksum = "de3df0aadc569a8b277808a7d0ad0e421180654ea36a3c59e9ed2bb968c9a1cd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -736,6 +752,7 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -807,14 +824,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-eips"
-version = "1.1.2"
+name = "alloy-eip7928"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd2c7ae05abcab4483ce821f12f285e01c0b33804e6883dd9ca1569a87ee2be"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh 1.6.1",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c0456f5f7a4497e9342d20f528e30f5288ddfa0d6a012bd5044afee46cd8a0"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
+ "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -826,14 +858,13 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.8",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc47eaae86488b07ea8e20236184944072a78784a1f4993f8ec17b3aa5d08c21"
+checksum = "a71ff8b55d2b8aa05259f474cae7dea0e4991724dc18936b81cb23ec492a0c2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -858,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003f46c54f22854a32b9cc7972660a476968008ad505427eabab49225309ec40"
+checksum = "19e352478b756bad5d7203148e4b461861282ea2ded3da406ba24868b52cd098"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -873,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4029954d9406a40979f3a3b46950928a0fdcfe3ea8a9b0c17490d57e8aa0e3"
+checksum = "ed08ae169869e08370ed121612e0d3dadac33d1a256e9f2465926b23f0bd7d95"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -899,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7805124ad69e57bbae7731c9c344571700b2a18d351bda9e0eba521c991d1bcb"
+checksum = "02e6c7ad28afe348a9a9c5624b67ee5b3607b8de98d5816b3056ecdfa6fa2697"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -929,7 +960,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
@@ -939,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d369e12c92870d069e0c9dc5350377067af8a056e29e3badf8446099d7e00889"
+checksum = "93a7c17472b55482d4734154c2f5ed13f72e03f6752cebb927f6a2d8b52e646c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -963,10 +994,10 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru 0.13.0",
+ "lru 0.16.2",
  "parking_lot 0.12.3",
- "pin-project 1.1.9",
- "reqwest 0.12.24",
+ "pin-project",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1000,17 +1031,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c89883fe6b7381744cbe80fef638ac488ead4f1956a4278956a1362c71cd2e"
+checksum = "5beb5c2fe6b960c8e8b038e69fd502a90a2e930afa4770efb748b163b0767729"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-transport",
  "alloy-transport-http",
  "futures",
- "pin-project 1.1.9",
- "reqwest 0.12.24",
+ "pin-project",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "tokio",
@@ -1023,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e279e6d40ee40fe8f76753b678d8d5d260cb276dc6c8a8026099b16d2b43f4"
+checksum = "4ee1257a278f6d293e05c5162c5940a1561b1aa85ded0028b464c81de37ebfa5"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -1035,20 +1066,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b43c1622aac2508d528743fd4cfdac1dea92d5a8fa894038488ff7edd0af0b32"
+checksum = "6a234bfbdf7a76c3d13808f729af5321852de3dedcaa6fc6d5f54787aaf54c6a"
 dependencies = [
  "alloy-consensus-any",
+ "alloy-network-primitives",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5fafb741c19b3cca4cdd04fa215c89413491f9695a3e928dee2ae5657f607e"
+checksum = "56a282daf869eeb7383d3d5c2deb35b0b3fb45ecb329513af4090fc61245ee18"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -1058,7 +1093,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1067,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f180c399ca7c1e2fe17ea58343910cad0090878a696ff5a50241aee12fc529"
+checksum = "a0eada2558e921b39dfcead33c487364df9b31374f5733c1c9d2c891c4529933"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -1078,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc39ad2c0a3d2da8891f4081565780703a593f090f768f884049aa3aa929cbc"
+checksum = "41eb29f7a8adcd8941fbb8e134022a133e6f8dfd345f2e3b7109599f8a7dca08"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -1095,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75411104af460ca0b306ae998f0a00b5159457780487630f4b24722beae6b690"
+checksum = "1258987fbc82716b5153ec7bb95a8a295e7640871b8f03d8ec7c4000dc80c215"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -1114,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-gcp"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd808e99893245e619babcc138af07191ded72dc42877e216006b1ebcae64a7"
+checksum = "7ffc2a49bca5b73c6964711b57452f6c36a6bcb7f845ab7e9ad05b5a828d0161"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -1132,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-ledger"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c059a3bbab204a06188ab27efad308b3f549c886a7853eaa64a79f76b453cae"
+checksum = "94e11ddaddfb98c1ddce737dc440225565b0ae0987ac9ad5e59a85db5904878c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -1152,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930e17cb1e46446a193a593a3bfff8d0ecee4e510b802575ebe300ae2e43ef75"
+checksum = "bef839e7ce9b59aa60fa9a175e97986c6145c888d643b0f1fb0a3e7b8e56a2e2"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -1168,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-turnkey"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f7c8b58378cede78b4a950a8a372779dfab1b22a2f096f89007616d87ea86"
+checksum = "82ff16b4166fb90bbe79bd1e49244824fb3cadc6b8cd11e9c8a002c1f8c07492"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -1257,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae82426d98f8bc18f53c5223862907cac30ab8fc5e4cd2bb50808e6d3ab43d8"
+checksum = "3ac7a80c0bac3e44559d53d002e34c461dc2f23262b42cafec019bc70551abbe"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl 1.2.0",
@@ -1280,13 +1315,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.1.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90aa6825760905898c106aba9c804b131816a15041523e80b6d4fe7af6380ada"
+checksum = "eed3ed3300a998f88639ed619fdbbd88bd82865e00c6a8ecb796c99eb12358f6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest 0.12.24",
+ "itertools 0.13.0",
+ "reqwest 0.13.1",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1295,27 +1331,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.1"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3412d52bb97c6c6cc27ccc28d4e6e8cf605469101193b50b0bd5813b1f990b5"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arrayvec",
  "derive_more 2.0.1",
  "nybbles",
  "serde",
  "smallvec",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.1.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae109e33814b49fc0a62f2528993aa8a2dd346c26959b151f05441dc0b9da292"
+checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -1661,9 +1697,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "ascii"
@@ -2057,7 +2090,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2334,7 +2367,7 @@ dependencies = [
  "http-body 0.4.6",
  "md-5 0.10.6",
  "pin-project-lite",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.8",
  "tracing",
 ]
@@ -3016,6 +3049,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,6 +3115,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "bnum"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119771309b95163ec7aaf79810da82f7cd0599c19722d48b9c03894dca833966"
 
 [[package]]
 name = "bnum"
@@ -3636,6 +3684,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3655,7 +3714,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
  "zeroize",
 ]
@@ -3728,10 +3787,11 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "clickhouse"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d6ac02411e84914fdf4e0565bfe02fc4bebdf375bd1fc58168bad74b3707a2"
+checksum = "d8063696febb0a10a6fb9df1460c52c509188f1d19da2157694ab3ca0feffc74"
 dependencies = [
+ "bnum 0.13.0",
  "bstr",
  "bytes",
  "chrono",
@@ -3744,14 +3804,14 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "lz4_flex",
+ "polonius-the-crab",
  "quanta",
- "replace_with",
- "sealed",
  "serde",
- "static_assertions 1.1.0",
+ "serde_json",
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tracing",
  "url",
  "uuid 1.11.0",
 ]
@@ -3770,9 +3830,9 @@ dependencies = [
 
 [[package]]
 name = "clickhouse-types"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235f72141cfbe1d2d930d8156a34814c8a3d60491febb9af64cc52a203444764"
+checksum = "30a5efddc880ce9e2573bd867413d9056fa2bea0206af88dec21e72178b9dc74"
 dependencies = [
  "bytes",
  "thiserror 2.0.18",
@@ -3913,15 +3973,14 @@ dependencies = [
 
 [[package]]
 name = "coins-ledger"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9bc0994d0aa0f4ade5f3a9baf4a8d936f250278c85a1124b401860454246ab"
+checksum = "c707b8909cef367cd04a11b0d71d65ab34a625d295a07869dd2fff2ca95bf688"
 dependencies = [
  "async-trait",
  "byteorder",
  "cfg-if",
  "const-hex",
- "getrandom 0.2.15",
  "hidapi-rusb",
  "js-sys",
  "log",
@@ -4069,7 +4128,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.15",
  "peg",
- "pin-project 1.1.9",
+ "pin-project",
  "rand 0.8.5",
  "reqwest 0.11.27",
  "semver 1.0.27",
@@ -4191,7 +4250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.13",
  "proptest",
  "serde_core",
 ]
@@ -4201,6 +4260,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-sha1"
@@ -4569,6 +4634,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4702,6 +4776,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4779,7 +4862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.13",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -4928,116 +5011,486 @@ dependencies = [
 [[package]]
 name = "dango-account"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
  "anyhow",
  "dango-auth",
+ "dango-primitives",
  "dango-types",
- "grug-types",
 ]
 
 [[package]]
 name = "dango-account-factory"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
  "anyhow",
  "dango-auth",
+ "dango-primitives",
+ "dango-storage",
  "dango-types",
- "grug-storage",
- "grug-types",
+]
+
+[[package]]
+name = "dango-app"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "async-trait",
+ "borsh 1.6.1",
+ "dango-backtrace",
+ "dango-dyn-event",
+ "dango-math",
+ "dango-primitives",
+ "dango-storage",
+ "data-encoding",
+ "prost 0.14.1",
+ "sha2 0.10.8",
+ "tendermint",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower 0.5.2",
+ "tower-abci",
+ "tracing",
 ]
 
 [[package]]
 name = "dango-auth"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
  "alloy",
  "anyhow",
+ "dango-primitives",
+ "dango-storage",
  "dango-types",
  "data-encoding",
- "grug-storage",
- "grug-types",
  "hex 0.4.3",
  "sha2 0.10.8",
 ]
 
 [[package]]
-name = "dango-bank"
+name = "dango-backtrace"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
  "anyhow",
+ "borsh 1.6.1",
+ "dango-backtrace-derive",
+ "serde",
+]
+
+[[package]]
+name = "dango-backtrace-derive"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dango-bank"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "anyhow",
+ "dango-math",
+ "dango-primitives",
+ "dango-storage",
  "dango-types",
- "grug-math",
- "grug-storage",
- "grug-types",
+]
+
+[[package]]
+name = "dango-crypto"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "blake2",
+ "blake3",
+ "dango-identity",
+ "ed25519-dalek",
+ "k256 0.13.4",
+ "p256 0.13.2",
+ "sha2 0.10.8",
+ "sha3",
+ "signature 2.2.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "dango-db-disk"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "dango-app",
+ "dango-backtrace",
+ "dango-primitives",
+ "hex 0.4.3",
+ "itertools 0.14.0",
+ "num_cpus",
+ "parking_lot 0.12.3",
+ "rocksdb",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "dango-db-memory"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "dango-app",
+ "dango-backtrace",
+ "dango-primitives",
+ "ouroboros",
+ "parking_lot 0.12.3",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "dango-disk-saver"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "borsh 1.6.1",
+ "dango-backtrace",
+ "lzma-rs",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "dango-dyn-event"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+
+[[package]]
+name = "dango-eth-utils"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "dango-identity",
+ "k256 0.13.4",
+ "sha3",
 ]
 
 [[package]]
 name = "dango-gateway"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
  "anyhow",
+ "dango-math",
+ "dango-primitives",
+ "dango-storage",
  "dango-types",
- "grug-math",
- "grug-storage",
- "grug-types",
 ]
 
 [[package]]
 name = "dango-genesis"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
  "anyhow",
  "dango-account",
  "dango-account-factory",
  "dango-bank",
  "dango-gateway",
+ "dango-hyperlane-ism",
+ "dango-hyperlane-mailbox",
+ "dango-hyperlane-types",
+ "dango-hyperlane-va",
+ "dango-math",
  "dango-oracle",
  "dango-order-book",
  "dango-perps",
- "dango-taxman",
+ "dango-primitives",
  "dango-types",
  "dango-vesting",
+ "dango-vm-rust",
  "dango-warp",
- "grug-math",
- "grug-types",
- "grug-vm-rust",
- "hyperlane-ism",
- "hyperlane-mailbox",
- "hyperlane-types",
- "hyperlane-va",
  "serde",
+]
+
+[[package]]
+name = "dango-hyperlane-ism"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "anyhow",
+ "dango-hyperlane-types",
+ "dango-primitives",
+ "dango-storage",
+]
+
+[[package]]
+name = "dango-hyperlane-mailbox"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "anyhow",
+ "dango-hyperlane-types",
+ "dango-primitives",
+ "dango-storage",
+]
+
+[[package]]
+name = "dango-hyperlane-types"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "anyhow",
+ "dango-primitives",
+ "dango-storage",
+ "hex-literal 1.1.0",
+ "sha3",
+]
+
+[[package]]
+name = "dango-hyperlane-va"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "anyhow",
+ "dango-hyperlane-mailbox",
+ "dango-hyperlane-types",
+ "dango-math",
+ "dango-primitives",
+ "dango-storage",
+]
+
+[[package]]
+name = "dango-identity"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "dango-indexer-cache"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "borsh 1.6.1",
+ "dango-app",
+ "dango-backtrace",
+ "dango-disk-saver",
+ "dango-primitives",
+ "lzma-rs",
+ "metrics",
+ "serde",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dango-indexer-clickhouse"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "async-graphql",
+ "bigdecimal",
+ "chrono",
+ "clickhouse",
+ "dango-app",
+ "dango-backtrace",
+ "dango-indexer-sql",
+ "dango-math",
+ "dango-order-book",
+ "dango-primitives",
+ "dango-types",
+ "futures",
+ "itertools 0.14.0",
+ "metrics",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dango-indexer-graphql-types"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "graphql_client",
+ "paste",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "dango-indexer-hooked"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "async-trait",
+ "dango-app",
+ "dango-indexer-cache",
+ "dango-indexer-clickhouse",
+ "dango-indexer-sql",
+ "dango-indexer-stream",
+ "dango-primitives",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dango-indexer-httpd"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "actix-cors",
+ "actix-files",
+ "actix-web",
+ "actix-web-metrics",
+ "actix-ws",
+ "anyhow",
+ "async-graphql",
+ "async-graphql-actix-web",
+ "async-trait",
+ "chrono",
+ "dango-app",
+ "dango-backtrace",
+ "dango-indexer-cache",
+ "dango-indexer-clickhouse",
+ "dango-indexer-sql",
+ "dango-indexer-stream",
+ "dango-primitives",
+ "dango-types",
+ "futures",
+ "futures-util",
+ "itertools 0.14.0",
+ "metrics",
+ "num_cpus",
+ "sea-orm",
+ "sentry",
+ "sentry-actix",
+ "serde",
+ "serde_json",
+ "tendermint",
+ "tendermint-rpc",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "dango-indexer-metrics"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "actix-web",
+ "actix-web-metrics",
+ "metrics-exporter-prometheus",
+ "sentry-actix",
+]
+
+[[package]]
+name = "dango-indexer-sql"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "anyhow",
+ "async-graphql",
+ "async-stream",
+ "async-trait",
+ "dango-app",
+ "dango-backtrace",
+ "dango-disk-saver",
+ "dango-indexer-cache",
+ "dango-primitives",
+ "dango-types",
+ "itertools 0.14.0",
+ "sea-orm",
+ "sea-orm-migration",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "uuid 1.11.0",
+]
+
+[[package]]
+name = "dango-indexer-stream"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "dango-app",
+ "dango-order-book",
+ "dango-primitives",
+ "dango-types",
+ "futures-util",
+ "metrics",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dango-macros"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dango-math"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "bnum 0.14.3",
+ "borsh 1.6.1",
+ "dango-backtrace",
+ "paste",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "dango-oracle"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
  "anyhow",
  "dango-order-book",
+ "dango-primitives",
+ "dango-pyth-types",
+ "dango-storage",
  "dango-types",
- "grug-storage",
- "grug-types",
  "hex 0.4.3",
- "pyth-types",
 ]
 
 [[package]]
 name = "dango-order-book"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
  "anyhow",
  "borsh 1.6.1",
- "grug-math",
- "grug-storage",
- "grug-types",
+ "dango-math",
+ "dango-primitives",
+ "dango-storage",
  "serde",
  "typenum",
 ]
@@ -5045,33 +5498,67 @@ dependencies = [
 [[package]]
 name = "dango-perps"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
  "anyhow",
  "dango-account-factory",
+ "dango-math",
  "dango-oracle",
  "dango-order-book",
+ "dango-primitives",
+ "dango-pyth-types",
+ "dango-storage",
  "dango-types",
- "grug-math",
- "grug-storage",
- "grug-types",
- "pyth-types",
  "tracing",
+]
+
+[[package]]
+name = "dango-primitives"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "async-graphql",
+ "async-trait",
+ "borsh 1.6.1",
+ "chrono",
+ "dango-backtrace",
+ "dango-crypto",
+ "dango-macros",
+ "dango-math",
+ "data-encoding",
+ "dyn-clone",
+ "hex-literal 1.1.0",
+ "ouroboros",
+ "parking_lot 0.12.3",
+ "paste",
+ "prost 0.14.1",
+ "ripemd",
+ "sea-orm",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.8",
+ "sha3",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
+ "tendermint",
+ "tendermint-rpc",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "dango-proposal-preparer"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
+ "dango-app",
+ "dango-math",
  "dango-order-book",
+ "dango-primitives",
+ "dango-pyth-client",
+ "dango-pyth-types",
  "dango-types",
- "grug-app",
- "grug-math",
- "grug-types",
  "prost 0.14.1",
- "pyth-client",
- "pyth-types",
  "reqwest 0.13.1",
  "tokio",
  "tokio-stream",
@@ -5079,9 +5566,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "dango-pyth-client"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "dango-disk-saver",
+ "dango-primitives",
+ "dango-pyth-types",
+ "pyth-lazer-client",
+ "pyth-lazer-protocol",
+ "reqwest 0.13.1",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "dango-pyth-types"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "dango-primitives",
+ "pyth-lazer-protocol",
+]
+
+[[package]]
 name = "dango-sdk"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -5089,14 +5605,14 @@ dependencies = [
  "async-trait",
  "bip32",
  "dango-auth",
+ "dango-backtrace",
+ "dango-eth-utils",
+ "dango-identity",
+ "dango-indexer-graphql-types",
+ "dango-primitives",
  "dango-types",
- "error-backtrace",
- "eth-utils",
  "futures",
  "graphql_client",
- "grug-types",
- "identity",
- "indexer-graphql-types",
  "k256 0.13.4",
  "pbkdf2 0.12.2",
  "rand 0.8.5",
@@ -5106,26 +5622,37 @@ dependencies = [
  "sha2 0.10.8",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite 0.29.0",
  "url",
 ]
 
 [[package]]
-name = "dango-taxman"
+name = "dango-storage"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
- "anyhow",
- "dango-types",
- "grug-math",
- "grug-storage",
- "grug-types",
+ "bnum 0.14.3",
+ "borsh 1.6.1",
+ "dango-macros",
+ "dango-math",
+ "dango-primitives",
+ "prost 0.14.1",
+ "serde",
+]
+
+[[package]]
+name = "dango-temp-rocksdb"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "rocksdb",
+ "tempfile",
 ]
 
 [[package]]
 name = "dango-testing"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -5137,42 +5664,42 @@ dependencies = [
  "awc",
  "byteorder",
  "clickhouse",
+ "dango-app",
+ "dango-backtrace",
+ "dango-crypto",
+ "dango-db-disk",
+ "dango-db-memory",
+ "dango-eth-utils",
  "dango-genesis",
+ "dango-hyperlane-types",
+ "dango-identity",
+ "dango-indexer-cache",
+ "dango-indexer-clickhouse",
+ "dango-indexer-graphql-types",
+ "dango-indexer-hooked",
+ "dango-indexer-httpd",
+ "dango-indexer-metrics",
+ "dango-indexer-sql",
+ "dango-math",
  "dango-order-book",
+ "dango-primitives",
  "dango-proposal-preparer",
+ "dango-pyth-client",
+ "dango-pyth-types",
+ "dango-temp-rocksdb",
  "dango-types",
- "error-backtrace",
- "eth-utils",
+ "dango-vm-rust",
  "futures",
  "futures-util",
  "graphql_client",
- "grug-app",
- "grug-crypto",
- "grug-db-disk",
- "grug-db-memory",
- "grug-math",
- "grug-types",
- "grug-vm-rust",
  "hex-literal 1.1.0",
- "hyperlane-types",
- "identity",
- "indexer-cache",
- "indexer-clickhouse",
- "indexer-graphql-types",
- "indexer-hooked",
- "indexer-httpd",
- "indexer-metrics",
- "indexer-sql",
  "k256 0.13.4",
- "pyth-client",
  "pyth-lazer-protocol",
- "pyth-types",
  "rand 0.8.5",
  "sea-orm",
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "temp-rocksdb",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5181,17 +5708,17 @@ dependencies = [
 [[package]]
 name = "dango-types"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
  "anyhow",
  "async-graphql",
  "async-trait",
+ "dango-hyperlane-types",
+ "dango-math",
  "dango-order-book",
- "grug-math",
- "grug-storage",
- "grug-types",
- "hyperlane-types",
- "pyth-types",
+ "dango-primitives",
+ "dango-pyth-types",
+ "dango-storage",
  "sea-orm",
  "serde",
  "sha2 0.10.8",
@@ -5200,26 +5727,39 @@ dependencies = [
 [[package]]
 name = "dango-vesting"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
  "anyhow",
+ "dango-math",
+ "dango-primitives",
+ "dango-storage",
  "dango-types",
- "grug-math",
- "grug-storage",
- "grug-types",
+]
+
+[[package]]
+name = "dango-vm-rust"
+version = "0.0.0"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
+dependencies = [
+ "dango-app",
+ "dango-backtrace",
+ "dango-primitives",
+ "elsa",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "dango-warp"
 version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+source = "git+https://github.com/left-curve/left-curve.git?rev=11bdf76#11bdf76c1d3c9423ffac1536d12ea30ec13186f8"
 dependencies = [
  "anyhow",
+ "dango-hyperlane-types",
+ "dango-math",
+ "dango-primitives",
+ "dango-storage",
  "dango-types",
- "grug-math",
- "grug-storage",
- "grug-types",
- "hyperlane-types",
 ]
 
 [[package]]
@@ -5324,7 +5864,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote 1.0.45",
- "serde",
  "strsim 0.11.1",
  "syn 2.0.117",
 ]
@@ -5338,6 +5877,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote 1.0.45",
+ "serde",
  "strsim 0.11.1",
  "syn 2.0.117",
 ]
@@ -5446,7 +5986,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -5456,7 +5996,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -5677,9 +6217,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
- "crypto-common",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -5721,19 +6272,6 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
-]
-
-[[package]]
-name = "disk-saver"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "borsh 1.6.1",
- "error-backtrace",
- "lzma-rs",
- "tempfile",
- "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -5835,11 +6373,6 @@ name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
-
-[[package]]
-name = "dyn-event"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
 
 [[package]]
 name = "ecdsa"
@@ -6146,27 +6679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "error-backtrace"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "anyhow",
- "borsh 1.6.1",
- "error-backtrace-derive",
- "serde",
-]
-
-[[package]]
-name = "error-backtrace-derive"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "quote 1.0.45",
- "syn 2.0.117",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6200,16 +6713,6 @@ dependencies = [
  "sha3",
  "thiserror 1.0.63",
  "uuid 0.8.2",
-]
-
-[[package]]
-name = "eth-utils"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "identity",
- "k256 0.13.4",
- "sha3",
 ]
 
 [[package]]
@@ -6333,7 +6836,7 @@ dependencies = [
  "futures-util",
  "hex 0.4.3",
  "once_cell",
- "pin-project 1.1.9",
+ "pin-project",
  "serde",
  "serde_json",
  "thiserror 1.0.63",
@@ -6493,7 +6996,7 @@ dependencies = [
  "http 0.2.12",
  "once_cell",
  "parking_lot 0.11.2",
- "pin-project 1.1.9",
+ "pin-project",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -6576,7 +7079,7 @@ dependencies = [
  "hyper-rustls 0.24.2",
  "hyper-timeout 0.4.1",
  "log",
- "pin-project 1.1.9",
+ "pin-project",
  "rand 0.8.5",
  "tokio",
 ]
@@ -6613,7 +7116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27cea6e7f512d43b098939ff4d5a5d6fe3db07971e1d05176fe26c642d33f5b8"
 dependencies = [
  "getrandom 0.3.2",
- "rand 0.9.2",
+ "rand 0.9.4",
  "siphasher 1.0.2",
  "wide",
 ]
@@ -7499,9 +8002,9 @@ dependencies = [
 
 [[package]]
 name = "gcloud-sdk"
-version = "0.27.4"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8458d2ad7741b6a16981b84e66b7e4d8026423096da721894769c6980d06ecc"
+checksum = "6b5b58d8683fa308be9bc58caece4972315a0b2547f9da16962511f0915d5b53"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7510,17 +8013,17 @@ dependencies = [
  "hyper 1.8.1",
  "jsonwebtoken",
  "once_cell",
- "prost 0.13.4",
- "prost-types 0.13.4",
- "reqwest 0.12.24",
+ "prost 0.14.1",
+ "prost-types 0.14.1",
+ "reqwest 0.13.1",
  "secret-vault-value",
  "serde",
  "serde_json",
  "tokio",
- "tonic 0.13.1",
+ "tonic 0.14.6",
+ "tonic-prost",
  "tower 0.5.2",
  "tower-layer",
- "tower-util",
  "tracing",
  "url",
 ]
@@ -7588,9 +8091,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.2.0",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -7637,9 +8152,9 @@ dependencies = [
 
 [[package]]
 name = "graphql-introspection-query"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2a4732cf5140bd6c082434494f785a19cfb566ab07d1382c3671f5812fed6d"
+checksum = "e063446242093b0acecc78a2313801e6c4faafa3501277b409a2b1972eff5d85"
 dependencies = [
  "serde",
 ]
@@ -7656,9 +8171,9 @@ dependencies = [
 
 [[package]]
 name = "graphql_client"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50cfdc7f34b7f01909d55c2dcb71d4c13cbcbb4a1605d6c8bd760d654c1144b"
+checksum = "b0f04840854efa7b06377d86fab117f598f5f5c95727067463417ccaf8aa7635"
 dependencies = [
  "graphql_query_derive",
  "serde",
@@ -7667,30 +8182,29 @@ dependencies = [
 
 [[package]]
 name = "graphql_client_codegen"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e27ed0c2cf0c0cc52c6bcf3b45c907f433015e580879d14005386251842fb0a"
+checksum = "aa0141e66c8d0302f8a586df12ad5d0cf87c0fa8c391f2f5b5dc296312dce569"
 dependencies = [
  "graphql-introspection-query",
  "graphql-parser",
  "heck 0.4.1",
- "lazy_static",
  "proc-macro2",
  "quote 1.0.45",
  "serde",
  "serde_json",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "graphql_query_derive"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83febfa838f898cfa73dfaa7a8eb69ff3409021ac06ee94cfb3d622f6eeb1a97"
+checksum = "e16ecf9bb87a6760cf5227f66cbe48bad7b89505aeb002aa9439ea090e6038a3"
 dependencies = [
  "graphql_client_codegen",
  "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7713,169 +8227,6 @@ dependencies = [
  "ff 0.13.0",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "grug-app"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "async-trait",
- "borsh 1.6.1",
- "data-encoding",
- "dyn-event",
- "error-backtrace",
- "grug-storage",
- "grug-types",
- "prost 0.14.1",
- "sha2 0.10.8",
- "tendermint",
- "thiserror 2.0.18",
- "tokio",
- "tower 0.5.2",
- "tower-abci",
- "tracing",
-]
-
-[[package]]
-name = "grug-crypto"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "blake2",
- "blake3",
- "ed25519-dalek",
- "identity",
- "k256 0.13.4",
- "p256 0.13.2",
- "sha2 0.10.8",
- "sha3",
- "signature 2.2.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "grug-db-disk"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "error-backtrace",
- "grug-app",
- "grug-types",
- "hex 0.4.3",
- "itertools 0.14.0",
- "num_cpus",
- "parking_lot 0.12.3",
- "rocksdb",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "grug-db-memory"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "error-backtrace",
- "grug-app",
- "grug-types",
- "ouroboros",
- "parking_lot 0.12.3",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "grug-jmt"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "borsh 1.6.1",
- "grug-app",
- "grug-storage",
- "grug-types",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "grug-macros"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "quote 1.0.45",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "grug-math"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "bnum 0.14.3",
- "borsh 1.6.1",
- "error-backtrace",
- "paste",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "grug-storage"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "bnum 0.14.3",
- "borsh 1.6.1",
- "grug-macros",
- "grug-math",
- "grug-types",
- "prost 0.14.1",
- "serde",
-]
-
-[[package]]
-name = "grug-types"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "async-graphql",
- "async-trait",
- "borsh 1.6.1",
- "chrono",
- "data-encoding",
- "dyn-clone",
- "error-backtrace",
- "grug-crypto",
- "grug-macros",
- "grug-math",
- "hex-literal 1.1.0",
- "ouroboros",
- "parking_lot 0.12.3",
- "paste",
- "prost 0.14.1",
- "ripemd",
- "sea-orm",
- "serde",
- "serde_json",
- "serde_with",
- "sha2 0.10.8",
- "sha3",
- "strum 0.28.0",
- "strum_macros 0.28.0",
- "tendermint",
- "tendermint-rpc",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "grug-vm-rust"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "elsa",
- "error-backtrace",
- "grug-app",
- "grug-types",
- "serde",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8045,7 +8396,7 @@ dependencies = [
  "http 0.2.12",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -8151,6 +8502,17 @@ dependencies = [
  "libc",
  "pkg-config",
  "rusb",
+]
+
+[[package]]
+name = "higher-kinded-types"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e690f8474c6c5d8ff99656fcbc195a215acc3949481a8b0b3351c838972dc776"
+dependencies = [
+ "macro_rules_attribute",
+ "never-say-never",
+ "paste",
 ]
 
 [[package]]
@@ -8295,6 +8657,15 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -8537,6 +8908,7 @@ dependencies = [
  "config",
  "console-subscriber",
  "convert_case 0.6.0",
+ "dango-primitives",
  "dango-types",
  "dashmap 5.5.3",
  "derive-new",
@@ -8548,7 +8920,6 @@ dependencies = [
  "fuels",
  "futures",
  "futures-util",
- "grug-types",
  "humantime",
  "hyperlane-aleo",
  "hyperlane-core",
@@ -8609,6 +8980,7 @@ dependencies = [
  "bytes",
  "config",
  "convert_case 0.6.0",
+ "dango-primitives",
  "derive-new",
  "derive_more 0.99.18",
  "ethers-contract",
@@ -8618,7 +8990,6 @@ dependencies = [
  "fixed-hash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "getrandom 0.2.15",
- "grug-types",
  "hex 0.4.3",
  "hyperlane-application",
  "itertools 0.14.0",
@@ -8672,7 +9043,7 @@ dependencies = [
  "injective-std",
  "itertools 0.14.0",
  "once_cell",
- "pin-project 1.1.9",
+ "pin-project",
  "protobuf 2.28.0",
  "ripemd",
  "serde",
@@ -8732,20 +9103,18 @@ dependencies = [
  "async-trait",
  "cargo_metadata 0.22.0",
  "dango-genesis",
+ "dango-hyperlane-types",
+ "dango-math",
+ "dango-primitives",
  "dango-sdk",
  "dango-testing",
  "dango-types",
  "dotenvy",
  "ethers",
  "futures-util",
- "grug-app",
- "grug-jmt",
- "grug-math",
- "grug-types",
  "hyperlane-base",
  "hyperlane-core",
  "hyperlane-operation-verifier",
- "hyperlane-types",
  "k256 0.13.4",
  "reqwest 0.11.27",
  "serde",
@@ -8810,28 +9179,6 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "url",
-]
-
-[[package]]
-name = "hyperlane-ism"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "anyhow",
- "grug-storage",
- "grug-types",
- "hyperlane-types",
-]
-
-[[package]]
-name = "hyperlane-mailbox"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "anyhow",
- "grug-storage",
- "grug-types",
- "hyperlane-types",
 ]
 
 [[package]]
@@ -9137,31 +9484,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyperlane-types"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "anyhow",
- "grug-storage",
- "grug-types",
- "hex-literal 1.1.0",
- "sha3",
-]
-
-[[package]]
-name = "hyperlane-va"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "anyhow",
- "grug-math",
- "grug-storage",
- "grug-types",
- "hyperlane-mailbox",
- "hyperlane-types",
-]
-
-[[package]]
 name = "hyperlane-warp-route"
 version = "2.2.0"
 dependencies = [
@@ -9326,14 +9648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
-name = "identity"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9479,158 +9793,6 @@ name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
-
-[[package]]
-name = "indexer-cache"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "borsh 1.6.1",
- "disk-saver",
- "error-backtrace",
- "grug-app",
- "grug-types",
- "metrics",
- "roaring",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "indexer-clickhouse"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "async-graphql",
- "bigdecimal",
- "chrono",
- "clickhouse",
- "dango-order-book",
- "dango-types",
- "error-backtrace",
- "futures",
- "grug-app",
- "grug-math",
- "grug-types",
- "indexer-sql",
- "itertools 0.14.0",
- "metrics",
- "serde",
- "serde_json",
- "strum 0.28.0",
- "strum_macros 0.28.0",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "indexer-graphql-types"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "graphql_client",
- "paste",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "indexer-hooked"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "async-trait",
- "grug-app",
- "grug-types",
- "indexer-cache",
- "indexer-clickhouse",
- "indexer-sql",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "indexer-httpd"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "actix-cors",
- "actix-files",
- "actix-web",
- "actix-web-metrics",
- "anyhow",
- "async-graphql",
- "async-graphql-actix-web",
- "async-trait",
- "chrono",
- "dango-types",
- "error-backtrace",
- "futures",
- "futures-util",
- "grug-app",
- "grug-types",
- "indexer-cache",
- "indexer-clickhouse",
- "indexer-sql",
- "itertools 0.14.0",
- "metrics",
- "num_cpus",
- "sea-orm",
- "sentry",
- "sentry-actix",
- "serde",
- "serde_json",
- "tendermint",
- "tendermint-rpc",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "indexer-metrics"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "actix-web",
- "actix-web-metrics",
- "metrics-exporter-prometheus",
- "sentry-actix",
-]
-
-[[package]]
-name = "indexer-sql"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "anyhow",
- "async-graphql",
- "async-stream",
- "async-trait",
- "dango-types",
- "disk-saver",
- "error-backtrace",
- "grug-app",
- "grug-types",
- "indexer-cache",
- "itertools 0.14.0",
- "sea-orm",
- "sea-orm-migration",
- "serde",
- "serde_json",
- "sqlx",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tracing",
- "uuid 1.11.0",
-]
 
 [[package]]
 name = "indexmap"
@@ -9896,16 +10058,17 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "base64 0.22.1",
+ "getrandom 0.2.15",
  "js-sys",
  "pem 3.0.6",
- "ring 0.17.8",
  "serde",
  "serde_json",
+ "signature 2.2.0",
  "simple_asn1",
 ]
 
@@ -9943,7 +10106,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.13",
 ]
 
 [[package]]
@@ -10061,7 +10224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -10251,15 +10414,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
-dependencies = [
- "hashbrown 0.15.2",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
@@ -10285,9 +10439,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "lzma-rs"
@@ -10453,7 +10607,7 @@ dependencies = [
  "hashbrown 0.15.2",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -10646,6 +10800,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "never-say-never"
+version = "6.6.666"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10717,7 +10877,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11620,31 +11780,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
-dependencies = [
- "pin-project-internal 0.4.30",
-]
-
-[[package]]
-name = "pin-project"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
 dependencies = [
- "pin-project-internal 1.1.9",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
-dependencies = [
- "proc-macro2",
- "quote 1.0.45",
- "syn 1.0.109",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -11733,12 +11873,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "polonius-the-crab"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec242d7eccbb2fd8b3b5b6e3cf89f94a91a800f469005b44d154359609f8af72"
+dependencies = [
+ "higher-kinded-types",
+ "never-say-never",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.13",
  "opaque-debug 0.3.1",
  "universal-hash",
 ]
@@ -11750,7 +11900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.13",
  "opaque-debug 0.3.1",
  "universal-hash",
 ]
@@ -12236,30 +12386,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyth-client"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "anyhow",
- "async-stream",
- "async-trait",
- "disk-saver",
- "grug-types",
- "pyth-lazer-client",
- "pyth-lazer-protocol",
- "pyth-types",
- "reqwest 0.13.1",
- "tokio",
- "tokio-stream",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "pyth-lazer-client"
-version = "22.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e458dbece9371c3bdef3f3aa4a04fe0b3921f785c9f0abce7a25945522bbbc"
+checksum = "9dec62fb119e67ffe644d2c43afaded07f9ebf4b541ece4fd229ac5818a57b15"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12289,9 +12419,9 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-protocol"
-version = "0.35.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d1f93509609f3cdb9924d7a696129f0228ce31c997abe074b8de59636f8e69"
+checksum = "b1eb48911f3dde91b8b6355bcd5fcc91ebd2e11aefe8061e041617d99313ec26"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -12302,6 +12432,7 @@ dependencies = [
  "humantime-serde",
  "itertools 0.13.0",
  "protobuf 3.7.2",
+ "protobuf-json-mapping",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -12312,9 +12443,9 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-publisher-sdk"
-version = "0.35.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1edcd716527d198a371264780ae11557ad3dc50f6dfda05dd418c7c634f22c6"
+checksum = "2a88299758202ecc6da12b77357d2cc9b866dc591f09d1f09431d6e41a93db2b"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12322,15 +12453,6 @@ dependencies = [
  "protobuf-codegen 3.7.2",
  "pyth-lazer-protocol",
  "serde_json",
-]
-
-[[package]]
-name = "pyth-types"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
-dependencies = [
- "grug-types",
- "pyth-lazer-protocol",
 ]
 
 [[package]]
@@ -12394,7 +12516,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.2",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring 0.17.8",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
@@ -12441,6 +12563,12 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -12614,13 +12742,24 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -12695,6 +12834,12 @@ dependencies = [
  "getrandom 0.3.2",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -12922,12 +13067,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "replace_with"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
-
-[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13005,7 +13144,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.37",
- "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -13021,7 +13159,6 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.0",
 ]
@@ -13049,6 +13186,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -13058,6 +13196,7 @@ dependencies = [
  "rustls-platform-verifier 0.6.1",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
@@ -13216,16 +13355,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "roaring"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08d6a905edb32d74a5d5737a0c9d7e950c312f3c46cb0ca0a2ca09ea11878a0"
-dependencies = [
- "bytemuck",
- "byteorder",
-]
-
-[[package]]
 name = "rocksdb"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13252,7 +13381,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
@@ -13316,7 +13445,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rlp 0.5.2",
  "ruint-macro",
  "serde_core",
@@ -13586,7 +13715,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14224,17 +14353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
-name = "sealed"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
-dependencies = [
- "proc-macro2",
- "quote 1.0.45",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "sec1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14341,12 +14459,10 @@ dependencies = [
 
 [[package]]
 name = "secret-vault-value"
-version = "0.3.10"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662c7f8e99d46c9d3a87561d771a970c29efaccbab4bbdc6ab65d099d2358077"
+checksum = "471de2a3d4b361569b862e04491696237381641ae5808f8e69ea08de991cd306"
 dependencies = [
- "prost 0.14.1",
- "prost-types 0.14.1",
  "serde",
  "serde_json",
  "zeroize",
@@ -14424,9 +14540,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "sentry"
-version = "0.47.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb25f439f97d26fea01d717fa626167ceffcd981addaa670001e70505b72acbb"
+checksum = "1975064d9f3d9d87a7c8f0371f7fac10d876906ca3e39faad72e61c263ff9b87"
 dependencies = [
  "cfg_aliases",
  "httpdate",
@@ -14446,9 +14562,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.47.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9453d18fc9a45d841636004aad50288d80cc07c34a9e88cd4397cb66e6356f67"
+checksum = "488b43adc03f07b01563ea078c33285c5a9bbbc34d07aaa483d82922db959637"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -14459,9 +14575,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.47.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a8c2c1bd5c1f735e84f28b48e7d72efcaafc362b7541bc8253e60e8fcdffc6"
+checksum = "134f552b6b147f77aeee46ece875d67a8bfc1d56fe3860d78446ed4c25bb5f9f"
 dependencies = [
  "backtrace",
  "regex",
@@ -14470,9 +14586,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.47.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b88a90baa654d7f0e1f4b667f6b434293d9f72c71bef16b197c76af5b7d5803"
+checksum = "98482b938fb1f31ecd23506fb7f08b2ba20d60b9cc72581b1205a9acd31d32fa"
 dependencies = [
  "hostname",
  "libc",
@@ -14484,11 +14600,11 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.47.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac170a5bba8bec6e3339c90432569d89641fa7a3d3e4f44987d24f0762e6adf"
+checksum = "7cff96247f4dc36867511d108709e703eb354143e7893319d763d2dd1edb4f48"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "sentry-types",
  "serde",
  "serde_json",
@@ -14497,9 +14613,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.47.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd9646a972b57896d4a92ed200cf76139f8e30b3cfd03b6662ae59926d26633c"
+checksum = "b603a51b083141062a142d73e36391b14244b4bd0bfe28bcd80e8327bb1d7698"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -14507,9 +14623,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.47.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235865e639f1d72414fa5d35374e105c292e2ee3a2f90919d961bbb486626ee6"
+checksum = "74df4d09a38fd59da258269ffd7f344bd308470117d68eda5a95b4fbd65683d0"
 dependencies = [
  "bitflags 2.11.0",
  "log",
@@ -14518,9 +14634,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.47.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6127d3d304ba5ce0409401e85aae538e303a569f8dbb031bf64f9ba0f7174346"
+checksum = "61de3f4a1fc77d4c57e8bacd8ef064c26aaa88ea5b2541a761d37c7c3703b9a9"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -14528,9 +14644,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.47.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27701acc51e68db5281802b709010395bfcbcb128b1d0a4e5873680d3b47ff0c"
+checksum = "bc59b27dae3bb495e37e6d62d252214840a2e7e1875531ee9fa2953df8985537"
 dependencies = [
  "bitflags 2.11.0",
  "sentry-backtrace",
@@ -14541,13 +14657,13 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.47.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56780cb5597d676bf22e6c11d1f062eb4def46390ea3bfb047bcbcf7dfd19bdb"
+checksum = "8d7e78132ccfb4a1c777b959fb2944d1f6d5145bffe6be2a98ee6b25d244f72c"
 dependencies = [
  "debugid",
  "hex 0.4.3",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -14803,7 +14919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.13",
  "digest 0.10.7",
 ]
 
@@ -14814,8 +14930,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.13",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -14838,7 +14965,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.13",
  "digest 0.9.0",
  "opaque-debug 0.3.1",
 ]
@@ -14850,7 +14977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.13",
  "digest 0.10.7",
 ]
 
@@ -16068,7 +16195,7 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "five8 1.0.0",
  "five8_const 1.0.0",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_derive",
  "sha2-const-stable",
@@ -16833,7 +16960,7 @@ dependencies = [
  "ed25519-dalek-bip32",
  "five8 1.0.0",
  "five8_core 1.0.0",
- "rand 0.9.2",
+ "rand 0.9.4",
  "solana-address 2.4.0",
  "solana-derivation-path 3.0.0",
  "solana-seed-derivable 3.0.0",
@@ -17947,7 +18074,7 @@ checksum = "132a93134f1262aa832f1849b83bec6c9945669b866da18661a427943b9e801e"
 dependencies = [
  "ed25519-dalek",
  "five8 1.0.0",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde-big-array",
  "serde_derive",
@@ -19084,7 +19211,7 @@ dependencies = [
  "rsa",
  "rust_decimal",
  "serde",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.8",
  "smallvec",
  "sqlx-core",
@@ -19341,7 +19468,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "zeroize",
 ]
@@ -19716,12 +19843,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "temp-rocksdb"
-version = "0.0.0"
-source = "git+https://github.com/left-curve/left-curve.git?rev=c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6#c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6"
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
- "rocksdb",
- "tempfile",
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -19734,7 +19863,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -19808,7 +19937,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.15",
  "peg",
- "pin-project 1.1.9",
+ "pin-project",
  "rand 0.8.5",
  "reqwest 0.11.27",
  "semver 1.0.27",
@@ -20016,9 +20145,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -20193,16 +20322,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
  "native-tls",
  "tokio",
  "tokio-native-tls",
- "tungstenite 0.28.0",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -20214,6 +20343,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -20296,7 +20426,7 @@ dependencies = [
  "hyper 0.14.30",
  "hyper-timeout 0.4.1",
  "percent-encoding",
- "pin-project 1.1.9",
+ "pin-project",
  "prost 0.12.6",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -20329,7 +20459,7 @@ dependencies = [
  "hyper-timeout 0.5.2",
  "hyper-util",
  "percent-encoding",
- "pin-project 1.1.9",
+ "pin-project",
  "prost 0.13.4",
  "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
@@ -20345,9 +20475,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum 0.8.4",
@@ -20361,10 +20491,9 @@ dependencies = [
  "hyper-timeout 0.5.2",
  "hyper-util",
  "percent-encoding",
- "pin-project 1.1.9",
- "prost 0.13.4",
- "rustls-native-certs 0.8.1",
- "socket2 0.5.7",
+ "pin-project",
+ "socket2 0.6.1",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.1",
  "tokio-stream",
@@ -20372,6 +20501,18 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost 0.14.1",
+ "tonic 0.14.6",
 ]
 
 [[package]]
@@ -20383,7 +20524,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap 1.9.3",
- "pin-project 1.1.9",
+ "pin-project",
  "pin-project-lite",
  "rand 0.8.5",
  "slab",
@@ -20421,7 +20562,7 @@ checksum = "1f20500d25342b86338bc9e053694dd199e9dafbc1044126a54ce378bfbbcfa5"
 dependencies = [
  "bytes",
  "futures",
- "pin-project 1.1.9",
+ "pin-project",
  "prost 0.13.4",
  "tendermint",
  "tendermint-proto",
@@ -20438,13 +20579,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -20463,22 +20609,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
-name = "tower-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project 0.4.30",
- "tower-service",
-]
-
-[[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -20499,9 +20633,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -20525,7 +20659,7 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "futures",
  "futures-task",
- "pin-project 1.1.9",
+ "pin-project",
  "tracing",
 ]
 
@@ -20661,7 +20795,7 @@ dependencies = [
  "native-tls",
  "rand 0.8.5",
  "rustls 0.21.12",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.63",
  "url",
  "utf-8",
@@ -20681,7 +20815,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.63",
  "url",
  "utf-8",
@@ -20689,9 +20823,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -20699,17 +20833,16 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand 0.9.2",
- "sha1",
+ "rand 0.9.4",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
 name = "turnkey_api_key_stamper"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b72664037582371dfa96bfaa2e272446ea2551e269455e9fe3166445c76736"
+checksum = "34f72e05a07cb04163efff0c766521ebacbb268a851db83d419b7c56df90d046"
 dependencies = [
  "base64 0.22.1",
  "hex 0.4.3",
@@ -20723,9 +20856,9 @@ dependencies = [
 
 [[package]]
 name = "turnkey_client"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf8cea094b6536ecc5cfad42cd45d2f9abf523cc7dacf7de23f132412d0ec3"
+checksum = "f216ea270ec4a37daa491679b716962cda7819cac982b49088979b2edf6067df"
 dependencies = [
  "mime",
  "prost 0.12.6",
@@ -20747,9 +20880,9 @@ checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
@@ -20898,7 +21031,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -21182,7 +21315,7 @@ dependencies = [
  "mime_guess",
  "multer 2.1.0",
  "percent-encoding",
- "pin-project 1.1.9",
+ "pin-project",
  "scoped-tls",
  "serde",
  "serde_json",

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -223,19 +223,13 @@ sbor = { git = "https://github.com/hyperlane-xyz/radixdlt-scrypto.git", branch =
 hyperlane-cosmos-rs = "0.1.4"
 
 ## dango
-# The `grug` meta-crate was removed upstream (left-curve #2088); `grug-types` is
-# now the umbrella crate (types + client + testing + macros), so we alias it as `grug`.
-grug = { git = "https://github.com/left-curve/left-curve.git", package = "grug-types", rev = "c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6" }
-grug-math = { git = "https://github.com/left-curve/left-curve.git", rev = "c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6" }
-grug-app = { git = "https://github.com/left-curve/left-curve.git", rev = "c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6" }
-grug-jmt = { git = "https://github.com/left-curve/left-curve.git", rev = "c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6" }
-# `dango-client` + `indexer-client` were consolidated into `dango-sdk` (left-curve #1939).
-dango-sdk = { git = "https://github.com/left-curve/left-curve.git", rev = "c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6" }
-dango-types = { git = "https://github.com/left-curve/left-curve.git", rev = "c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6" }
-dango-hyperlane-types = { git = "https://github.com/left-curve/left-curve.git", package = "hyperlane-types", rev = "c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6" }
-# `dango-mock-httpd` was collapsed into `dango-testing` (left-curve #2089).
-dango-testing = { git = "https://github.com/left-curve/left-curve.git", rev = "c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6" }
-dango-genesis = { git = "https://github.com/left-curve/left-curve.git", rev = "c2950a3cbe5e83a9b1944ee0de920f8cddd85fe6" }
+dango-genesis = { git = "https://github.com/left-curve/left-curve.git", rev = "11bdf76" }
+dango-hyperlane-types = { git = "https://github.com/left-curve/left-curve.git", rev = "11bdf76" }
+dango-math = { git = "https://github.com/left-curve/left-curve.git", rev = "11bdf76" }
+dango-primitives = { git = "https://github.com/left-curve/left-curve.git", rev = "11bdf76" }
+dango-sdk = { git = "https://github.com/left-curve/left-curve.git", rev = "11bdf76" }
+dango-testing = { git = "https://github.com/left-curve/left-curve.git", rev = "11bdf76" }
+dango-types = { git = "https://github.com/left-curve/left-curve.git", rev = "11bdf76" }
 
 ## TODO: remove this
 cosmwasm-schema = "2.2.0"

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -743,16 +743,21 @@ impl PendingMessage {
         origin_db: Arc<dyn HyperlaneDb>,
         message: &HyperlaneMessage,
     ) -> PendingOperationStatus {
+        // tracing >= 0.1.44 requires the event level to live for 'static; an
+        // inline `if` expression creates a temporary that is dropped too early,
+        // so hoist it into a const.
+        const STATUS_LOG_LEVEL: Level = if cfg!(feature = "test-utils") {
+            Level::DEBUG
+        } else {
+            Level::TRACE
+        };
+
         // Attempt to fetch status about message from database
         if let Ok(Some(status)) = origin_db.retrieve_status_by_message_id(&message.id()) {
             // This event is used for E2E tests to ensure message statuses
             // are being properly loaded from the db
             tracing::event!(
-                if cfg!(feature = "test-utils") {
-                    Level::DEBUG
-                } else {
-                    Level::TRACE
-                },
+                STATUS_LOG_LEVEL,
                 ?status,
                 id=?message.id(),
                 RETRIEVED_MESSAGE_LOG,
@@ -760,14 +765,8 @@ impl PendingMessage {
             return status;
         }
 
-        tracing::event!(
-            if cfg!(feature = "test-utils") {
-                Level::DEBUG
-            } else {
-                Level::TRACE
-            },
-            "Message status not found in db"
-        );
+        tracing::event!(STATUS_LOG_LEVEL, "Message status not found in db");
+
         PendingOperationStatus::FirstPrepareAttempt
     }
 

--- a/rust/main/chains/hyperlane-dango/Cargo.toml
+++ b/rust/main/chains/hyperlane-dango/Cargo.toml
@@ -10,14 +10,12 @@ version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+dango-hyperlane-types = { workspace = true }
+dango-math = { workspace = true }
+dango-primitives = { workspace = true }
 dango-sdk = { workspace = true }
 dango-types = { workspace = true }
-dango-hyperlane-types = { workspace = true }
 futures-util = { workspace = true }
-grug = { workspace = true }
-grug-app = { workspace = true }
-grug-jmt = { workspace = true }
-grug-math = { workspace = true }
 hyperlane-core = { path = "../../hyperlane-core", features = ["async"] }
 hyperlane-operation-verifier = { path = "../../applications/hyperlane-operation-verifier" }
 serde = { workspace = true }

--- a/rust/main/chains/hyperlane-dango/src/contracts/ism/core.rs
+++ b/rust/main/chains/hyperlane-dango/src/contracts/ism/core.rs
@@ -5,7 +5,7 @@ use {
     },
     async_trait::async_trait,
     dango_hyperlane_types::isms,
-    grug::QueryClientExt,
+    dango_primitives::QueryClientExt,
     hyperlane_core::{
         ChainResult, ContractLocator, HyperlaneMessage, InterchainSecurityModule, Metadata,
         ModuleType, RawHyperlaneMessage, H256, U256,
@@ -51,7 +51,6 @@ impl InterchainSecurityModule for DangoIsm {
                     raw_message: RawHyperlaneMessage::from(message).into(),
                     raw_metadata: metadata.to_vec().into(),
                 }),
-                None,
             )
             .await?;
 

--- a/rust/main/chains/hyperlane-dango/src/contracts/ism/multisig.rs
+++ b/rust/main/chains/hyperlane-dango/src/contracts/ism/multisig.rs
@@ -3,7 +3,7 @@ use {
     crate::{DangoConvertor, TryDangoConvertor},
     async_trait::async_trait,
     dango_hyperlane_types::isms,
-    grug::QueryClientExt,
+    dango_primitives::QueryClientExt,
     hyperlane_core::{ChainResult, HyperlaneMessage, MultisigIsm, H256},
 };
 
@@ -20,7 +20,6 @@ impl MultisigIsm for DangoIsm {
                 isms::multisig::QueryValidatorSetRequest {
                     domain: message.origin,
                 },
-                None,
             )
             .await?;
 

--- a/rust/main/chains/hyperlane-dango/src/contracts/mailbox/core.rs
+++ b/rust/main/chains/hyperlane-dango/src/contracts/mailbox/core.rs
@@ -5,7 +5,7 @@ use {
     },
     async_trait::async_trait,
     dango_hyperlane_types::{mailbox, recipients::RecipientQuery},
-    grug::{Coins, HexBinary, Message, QueryClientExt},
+    dango_primitives::{Coins, HexBinary, Message, QueryClientExt},
     hyperlane_core::{
         ChainResult, ContractLocator, HyperlaneMessage, Mailbox, Metadata, RawHyperlaneMessage,
         ReorgPeriod, TxCostEstimate, TxOutcome, H256, U256,
@@ -39,11 +39,7 @@ impl Mailbox for DangoMailbox {
         self.provider.validate_reorg_period(reorg_period).await?;
         Ok(self
             .provider
-            .query_wasm_smart(
-                self.address.try_convert()?,
-                mailbox::QueryNonceRequest {},
-                None,
-            )
+            .query_wasm_smart(self.address.try_convert()?, mailbox::QueryNonceRequest {})
             .await?)
     }
 
@@ -56,7 +52,6 @@ impl Mailbox for DangoMailbox {
                 mailbox::QueryDeliveredRequest {
                     message_id: id.convert(),
                 },
-                None,
             )
             .await?)
     }
@@ -65,11 +60,7 @@ impl Mailbox for DangoMailbox {
     async fn default_ism(&self) -> ChainResult<H256> {
         Ok(self
             .provider
-            .query_wasm_smart(
-                self.address.try_convert()?,
-                mailbox::QueryConfigRequest {},
-                None,
-            )
+            .query_wasm_smart(self.address.try_convert()?, mailbox::QueryConfigRequest {})
             .await?
             .default_ism
             .convert())
@@ -84,7 +75,6 @@ impl Mailbox for DangoMailbox {
                 dango_hyperlane_types::recipients::QueryRecipientRequest(
                     RecipientQuery::InterchainSecurityModule {},
                 ),
-                None,
             )
             .await?
             .into_interchain_security_module()

--- a/rust/main/chains/hyperlane-dango/src/contracts/mailbox/indexer.rs
+++ b/rust/main/chains/hyperlane-dango/src/contracts/mailbox/indexer.rs
@@ -6,7 +6,7 @@ use {
         crate::{DangoConvertor, SearchLog, TryDangoConvertor},
         async_trait::async_trait,
         dango_hyperlane_types::mailbox,
-        grug::{Inner, SearchTxClient},
+        dango_primitives::{Inner, SearchTxClient},
         hyperlane_core::{
             ChainResult, HyperlaneContract, HyperlaneMessage, Indexed, Indexer, LogMeta,
             SequenceAwareIndexer, H256, H512,

--- a/rust/main/chains/hyperlane-dango/src/contracts/merkle_tree/core.rs
+++ b/rust/main/chains/hyperlane-dango/src/contracts/merkle_tree/core.rs
@@ -8,7 +8,7 @@ use {
     dango_hyperlane_types::{
         mailbox::QueryTreeRequest, IncrementalMerkleTree as DangoIncrementalMerkleTree,
     },
-    grug::{QueryClientExt, QueryResponse},
+    dango_primitives::{QueryClientExt, QueryResponse},
     hyperlane_core::{
         accumulator::incremental::IncrementalMerkle, ChainCommunicationError, ChainResult,
         Checkpoint, CheckpointAtBlock, ContractLocator, HyperlaneContract,
@@ -155,7 +155,7 @@ impl DangoMerkleTree {
 
     pub async fn dango_tree(&self) -> ChainResult<DangoIncrementalMerkleTree> {
         self.provider
-            .query_wasm_smart(self.address.try_convert()?, QueryTreeRequest {}, None)
+            .query_wasm_smart(self.address.try_convert()?, QueryTreeRequest {})
             .await
     }
 

--- a/rust/main/chains/hyperlane-dango/src/contracts/merkle_tree/indexer.rs
+++ b/rust/main/chains/hyperlane-dango/src/contracts/merkle_tree/indexer.rs
@@ -3,7 +3,7 @@ use {
     crate::{DangoConvertor, SearchLog, SearchTxOutcomeExt, TryDangoConvertor},
     async_trait::async_trait,
     dango_hyperlane_types::mailbox::PostDispatch,
-    grug::SearchTxClient,
+    dango_primitives::SearchTxClient,
     hyperlane_core::{
         ChainResult, HyperlaneContract, Indexed, Indexer, LogMeta, MerkleTreeInsertion,
         SequenceAwareIndexer, H512,

--- a/rust/main/chains/hyperlane-dango/src/contracts/va/core.rs
+++ b/rust/main/chains/hyperlane-dango/src/contracts/va/core.rs
@@ -8,8 +8,8 @@ use {
     dango_hyperlane_types::va::{
         ExecuteMsg, QueryAnnounceFeePerByteRequest, QueryAnnouncedStorageLocationsRequest,
     },
-    grug::{Coin, Inner, Message, QueryClientExt},
-    grug_math::{Number, Uint128},
+    dango_math::{Number, Uint128},
+    dango_primitives::{Coin, Inner, Message, QueryClientExt},
     hyperlane_core::{
         Announcement, ChainResult, ContractLocator, SignedType, TxOutcome, ValidatorAnnounce, H256,
         U256,
@@ -42,7 +42,6 @@ impl DangoValidatorAnnounce {
             .query_wasm_smart(
                 self.address.try_convert()?,
                 QueryAnnounceFeePerByteRequest {},
-                None,
             )
             .await?;
 
@@ -62,7 +61,7 @@ impl DangoValidatorAnnounce {
 
         let balance = self
             .provider
-            .query_balance(signer.try_convert()?, coins.denom, None)
+            .query_balance(signer.try_convert()?, coins.denom)
             .await?;
 
         Ok(coins.amount.saturating_sub(balance).into_inner().into())
@@ -88,7 +87,6 @@ impl ValidatorAnnounce for DangoValidatorAnnounce {
             .query_wasm_smart(
                 self.address.try_convert()?,
                 QueryAnnouncedStorageLocationsRequest { validators },
-                None,
             )
             .await?;
 

--- a/rust/main/chains/hyperlane-dango/src/types/client_wrapper.rs
+++ b/rust/main/chains/hyperlane-dango/src/types/client_wrapper.rs
@@ -1,15 +1,15 @@
 use {
     async_trait::async_trait,
-    grug::BlockClient,
+    dango_primitives::BlockClient,
     hyperlane_core::{rpc_clients::BlockNumberGetter, ChainResult},
     std::ops::Deref,
 };
 
-/// We need to define a wrapper around grug::ClientWrapper because we need to implement
+/// We need to define a wrapper around dango_primitives::ClientWrapper because we need to implement
 /// BlockNumberGetter in order to use FallbackProvider for DangoProvider.
 #[derive(Clone)]
 pub struct ClientWrapper {
-    inner: grug::ClientWrapper<anyhow::Error>,
+    inner: dango_primitives::ClientWrapper<anyhow::Error>,
 }
 
 impl std::fmt::Debug for ClientWrapper {
@@ -19,7 +19,7 @@ impl std::fmt::Debug for ClientWrapper {
 }
 
 impl ClientWrapper {
-    pub fn new(inner: grug::ClientWrapper<anyhow::Error>) -> Self {
+    pub fn new(inner: dango_primitives::ClientWrapper<anyhow::Error>) -> Self {
         Self { inner }
     }
 }
@@ -35,7 +35,7 @@ impl BlockNumberGetter for ClientWrapper {
 }
 
 impl Deref for ClientWrapper {
-    type Target = grug::ClientWrapper<anyhow::Error>;
+    type Target = dango_primitives::ClientWrapper<anyhow::Error>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/rust/main/chains/hyperlane-dango/src/types/config.rs
+++ b/rust/main/chains/hyperlane-dango/src/types/config.rs
@@ -1,6 +1,6 @@
 use {
     crate::{DangoProvider, DangoResult, DangoSigner},
-    grug::Coin,
+    dango_primitives::Coin,
     hyperlane_core::{config::OpSubmissionConfig, HyperlaneDomain, HyperlaneProvider},
     std::time::Duration,
     url::Url,

--- a/rust/main/chains/hyperlane-dango/src/types/convertor.rs
+++ b/rust/main/chains/hyperlane-dango/src/types/convertor.rs
@@ -1,7 +1,7 @@
 use {
     crate::{DangoError, DangoResult},
     dango_hyperlane_types::Addr32,
-    grug::{EncodedBytes, Encoder, Hash256, Inner},
+    dango_primitives::{EncodedBytes, Encoder, Hash256, Inner},
     hyperlane_core::{H160, H256, H512},
     tendermint::Hash as TmHash,
 };

--- a/rust/main/chains/hyperlane-dango/src/types/error.rs
+++ b/rust/main/chains/hyperlane-dango/src/types/error.rs
@@ -1,4 +1,4 @@
-use {grug::Hash256, hyperlane_core::ChainCommunicationError, std::fmt::Debug};
+use {dango_primitives::Hash256, hyperlane_core::ChainCommunicationError, std::fmt::Debug};
 
 pub type DangoResult<T> = Result<T, DangoError>;
 
@@ -14,7 +14,7 @@ pub enum DangoError {
     Anyhow(#[from] anyhow::Error),
 
     #[error(transparent)]
-    StdError(#[from] grug::StdError),
+    StdError(#[from] dango_primitives::StdError),
 
     #[error("failed to convert {ty_from} to {ty_to}: from {from}, reason: {reason}")]
     WrongConversion {

--- a/rust/main/chains/hyperlane-dango/src/types/log.rs
+++ b/rust/main/chains/hyperlane-dango/src/types/log.rs
@@ -1,7 +1,7 @@
 use {
     crate::{DangoConvertor, DangoProvider, DangoResult},
     async_trait::async_trait,
-    grug::{
+    dango_primitives::{
         Addr, Addressable, BlockClient, CheckedContractEvent, CronOutcome, EventFilter, EventId,
         Hash256, HashExt, JsonDeExt, SearchEvent, SearchTxOutcome, Tx,
     },
@@ -140,7 +140,7 @@ impl SearchLog for BlockLogs {
     {
         let filter_closure = |filter: EventFilter<CheckedContractEvent>| {
             filter
-                .with_commitment_status(grug::FlatCommitmentStatus::Committed)
+                .with_commitment_status(dango_primitives::FlatCommitmentStatus::Committed)
                 .with_predicate(move |e| e.contract == contract)
                 .take()
                 .all()

--- a/rust/main/chains/hyperlane-dango/src/types/provider.rs
+++ b/rust/main/chains/hyperlane-dango/src/types/provider.rs
@@ -5,15 +5,15 @@ use {
     },
     anyhow::anyhow,
     async_trait::async_trait,
-    dango_sdk::HttpClient,
-    dango_types::{account, auth::Metadata},
-    futures_util::future::try_join_all,
-    grug::{
-        Addr, Binary, Block, BlockClient, BlockOutcome, BroadcastClient, BroadcastClientExt,
+    dango_primitives::{
+        Addr, Block, BlockClient, BlockOutcome, BroadcastClient, BroadcastClientExt,
         BroadcastTxOutcome, Defined, GasOption, Hash256, Inner, JsonDeExt, JsonSerExt, Message,
         MsgExecute, NonEmpty, Query, QueryClient, QueryClientExt, QueryRequest, QueryResponse,
         SearchTxClient, SearchTxOutcome, Signer, Tx, TxOutcome, UnsignedTx,
     },
+    dango_sdk::HttpClient,
+    dango_types::{account, auth::Metadata},
+    futures_util::future::try_join_all,
     hyperlane_core::{
         rpc_clients::{BlockNumberGetter, FallbackProvider},
         BlockInfo, ChainCommunicationError, ChainInfo, ChainResult, HyperlaneChain,
@@ -46,8 +46,9 @@ impl DangoProvider {
             .httpd_urls
             .iter()
             .map(|url| {
-                HttpClient::new(url.clone())
-                    .map(|client| ClientWrapper::new(grug::ClientWrapper::new(Arc::new(client))))
+                HttpClient::new(url.clone()).map(|client| {
+                    ClientWrapper::new(dango_primitives::ClientWrapper::new(Arc::new(client)))
+                })
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -155,7 +156,6 @@ impl DangoProvider {
             .query_wasm_smart(
                 signer.r#use(self).await?.read().await.deref().address,
                 account::QuerySeenNoncesRequest {},
-                None,
             )
             .await?
             .last()
@@ -230,7 +230,7 @@ impl DangoProvider {
 
     /// Get the latest block number
     pub async fn latest_block(&self) -> ChainResult<u64> {
-        self.query_status(None)
+        self.query_status()
             .await
             .map(|res| res.last_finalized_block.height)
     }
@@ -248,7 +248,7 @@ impl DangoProvider {
         let msg = R::Message::from(req);
 
         let [wasm_smart_response, status_response] = self
-            .query_multi([Query::wasm_smart(contract, &msg)?, Query::status()], None)
+            .query_multi([Query::wasm_smart(contract, &msg)?, Query::status()])
             .await?;
 
         Ok((
@@ -324,7 +324,7 @@ impl HyperlaneProvider for DangoProvider {
 
     /// Returns whether a contract exists at the provided address
     async fn is_contract(&self, address: &H256) -> ChainResult<bool> {
-        match self.query_contract(address.try_convert()?, None).await {
+        match self.query_contract(address.try_convert()?).await {
             Ok(_) => Ok(true),
             Err(_) => Ok(false),
         }
@@ -335,7 +335,7 @@ impl HyperlaneProvider for DangoProvider {
         let address = Addr::from_str(&address)?;
 
         let balance = self
-            .query_balance(address, self.connection_conf.gas_price.denom.clone(), None)
+            .query_balance(address, self.connection_conf.gas_price.denom.clone())
             .await?;
 
         Ok(balance.into_inner().into())
@@ -365,32 +365,13 @@ impl BlockNumberGetter for DangoProvider {
 #[async_trait]
 impl QueryClient for DangoProvider {
     type Error = ChainCommunicationError;
-    type Proof = grug::Proof;
+    type Proof = dango_primitives::Proof;
 
-    async fn query_app(
-        &self,
-        query: Query,
-        height: Option<u64>,
-    ) -> Result<QueryResponse, Self::Error> {
+    async fn query_app(&self, query: Query) -> Result<QueryResponse, Self::Error> {
         self.client
             .call(|client| {
                 let query = query.clone();
-                let future = async move { Ok(client.query_app(query, height).await?) };
-                Box::pin(future)
-            })
-            .await
-    }
-
-    async fn query_store(
-        &self,
-        key: Binary,
-        height: Option<u64>,
-        prove: bool,
-    ) -> Result<(Option<Binary>, Option<Self::Proof>), Self::Error> {
-        self.client
-            .call(|client| {
-                let key = key.clone();
-                let future = async move { Ok(client.query_store(key, height, prove).await?) };
+                let future = async move { Ok(client.query_app(query).await?) };
                 Box::pin(future)
             })
             .await

--- a/rust/main/chains/hyperlane-dango/src/types/singer.rs
+++ b/rust/main/chains/hyperlane-dango/src/types/singer.rs
@@ -1,8 +1,8 @@
 use {
     crate::DangoResult,
+    dango_primitives::{Addr, Defined, QueryClient},
     dango_sdk::{Secp256k1, Secret, SingleSigner},
     dango_types::auth::Nonce,
-    grug::{Addr, Defined, QueryClient},
     std::sync::Arc,
     tokio::sync::RwLock,
 };

--- a/rust/main/chains/hyperlane-dango/tests/integration.rs
+++ b/rust/main/chains/hyperlane-dango/tests/integration.rs
@@ -3,9 +3,9 @@ use {
         build_agents, get_free_port, startup_tests, try_for, Agent, CheckpointSyncer, DangoBuilder,
         DangoSettings, HexKey, Location, Relayer, SetupChain, Validator, ValidatorSigner,
     },
+    dango_primitives::{btree_set, Coin, Denom, Part, QueryClientExt, ResultExt},
     dango_testing::{setup_tracing_subscriber, BlockCreation},
     dango_types::{constants::dango, gateway::Origin},
-    grug::{btree_set, Coin, Denom, Part, QueryClientExt, ResultExt},
     std::time::Duration,
     tracing::Level,
 };
@@ -123,7 +123,6 @@ async fn dango_one_way() -> anyhow::Result<()> {
                 .query_balance(
                     ch2.accounts.user3.address.into_inner(),
                     Denom::new_unchecked(["bridge", "foo"]),
-                    None,
                 )
                 .await?;
             if balance.0 == 100 {
@@ -178,7 +177,6 @@ async fn dango_multiple_chains() -> anyhow::Result<()> {
                 .query_balance(
                     ch2.accounts.user1.address.into_inner(),
                     remote_denom.clone(),
-                    None,
                 )
                 .await?;
 
@@ -196,7 +194,6 @@ async fn dango_multiple_chains() -> anyhow::Result<()> {
         .query_balance(
             ch1.accounts.user1.address.into_inner(),
             dango::DENOM.clone(),
-            None,
         )
         .await?;
 
@@ -221,7 +218,6 @@ async fn dango_multiple_chains() -> anyhow::Result<()> {
                 .query_balance(
                     ch1.accounts.user1.address.into_inner(),
                     dango::DENOM.clone(),
-                    None,
                 )
                 .await?;
 

--- a/rust/main/chains/hyperlane-dango/tests/localdango.rs
+++ b/rust/main/chains/hyperlane-dango/tests/localdango.rs
@@ -6,6 +6,11 @@ use {
         isms::{multisig::ValidatorSet, HYPERLANE_DOMAIN_KEY},
         mailbox, multisig_hash, Addr32,
     },
+    dango_primitives::{
+        __private::hex_literal::hex, addr, btree_map, btree_set, Addr, Api, BroadcastClientExt,
+        CheckedContractEvent, Coins, EventName, FlatCommitmentStatus, GasOption, Hash256, Inner,
+        JsonDeExt, MockApi, QueryClientExt, ResultExt, SearchEvent, SearchTxClient,
+    },
     dango_sdk::HttpClient,
     dango_sdk::{Secp256k1, Secret, SingleSigner},
     dango_testing::{user5, Preset},
@@ -13,11 +18,6 @@ use {
         config::AppConfig,
         constants::dango,
         gateway::{self, Origin, Remote},
-    },
-    grug::{
-        __private::hex_literal::hex, addr, btree_map, btree_set, Addr, Api, BroadcastClientExt,
-        CheckedContractEvent, Coins, EventName, FlatCommitmentStatus, GasOption, Hash256, Inner,
-        JsonDeExt, MockApi, QueryClientExt, ResultExt, SearchEvent, SearchTxClient,
     },
     manual_relay::get_checkpoint_from_s3,
     std::time::Duration,
@@ -72,7 +72,7 @@ async fn run_dango() -> anyhow::Result<()> {
 
     DangoBuilder::new("localdango", local_domain)
         .with_block_creation(dango_testing::BlockCreation::Timed)
-        .with_block_time(grug::Duration::from_seconds(1))
+        .with_block_time(dango_primitives::Duration::from_seconds(1))
         .with_port(PORT)
         .with_genesis_option(GenesisOption {
             gateway: GatewayOption {
@@ -114,8 +114,8 @@ async fn transfer_remote() -> anyhow::Result<()> {
 
     let dango_client = HttpClient::new(url)?;
 
-    let cfg: AppConfig = dango_client.query_app_config(None).await?;
-    let chain_id = dango_client.query_status(None).await?.chain_id;
+    let cfg: AppConfig = dango_client.query_app_config().await?;
+    let chain_id = dango_client.query_status().await?.chain_id;
 
     let mut user5 = SingleSigner::new_first_account(
         &dango_client,

--- a/rust/main/chains/hyperlane-dango/tests/manual_relay.rs
+++ b/rust/main/chains/hyperlane-dango/tests/manual_relay.rs
@@ -5,6 +5,11 @@ use {
         mailbox::Message,
         multisig_hash, Addr32,
     },
+    dango_primitives::{
+        __private::hex_literal::hex, addr, btree_set, Addr, AddrEncoder, Api, BroadcastClientExt,
+        Coins, EncodedBytes, GasOption, Hash256, HexByteArray, Inner, Json, JsonDeExt, JsonSerExt,
+        MockApi, QueryClientExt,
+    },
     dango_sdk::HttpClient,
     dango_sdk::{Secp256k1, Secret, SingleSigner},
     dango_testing::user4,
@@ -14,11 +19,6 @@ use {
         providers::{Http, Provider},
         types::H160,
         utils::keccak256,
-    },
-    grug::{
-        __private::hex_literal::hex, addr, btree_set, Addr, AddrEncoder, Api, BroadcastClientExt,
-        Coins, EncodedBytes, GasOption, Hash256, HexByteArray, Inner, Json, JsonDeExt, JsonSerExt,
-        MockApi, QueryClientExt,
     },
     serde::{Deserialize, Serialize},
     std::{
@@ -194,8 +194,8 @@ async fn manual_relay() -> anyhow::Result<()> {
 
     let dango_client = HttpClient::new(DANGO_URL)?;
 
-    let app_config: AppConfig = dango_client.query_app_config(None).await?;
-    let chain_id = dango_client.query_status(None).await?.chain_id;
+    let app_config: AppConfig = dango_client.query_app_config().await?;
+    let chain_id = dango_client.query_status().await?.chain_id;
 
     let mut dango_signer =
         SingleSigner::new(DANGO_ADDRESS, Secp256k1::from_bytes(DANGO_PRIVATE_KEY)?)

--- a/rust/main/chains/hyperlane-dango/tests/run_agents.rs
+++ b/rust/main/chains/hyperlane-dango/tests/run_agents.rs
@@ -3,11 +3,11 @@ use {
         build_agents, workspace, Agent, CheckpointSyncer, DangoSettings, EvmSettings, Location,
         LogLevel, Relayer, SingleSignerExt, Validator, ValidatorSigner,
     },
+    dango_primitives::{HexByteArray, QueryClientExt},
     dango_sdk::HttpClient,
     dango_sdk::{Secp256k1, Secret, SingleSigner},
     dango_testing::{user4, user6},
     dango_types::config::AppConfig,
-    grug::{HexByteArray, QueryClientExt},
     hyperlane_base::settings::SignerConf,
     hyperlane_core::H256,
     std::str::FromStr,
@@ -33,7 +33,7 @@ async fn run_relayer() -> anyhow::Result<()> {
     build_agents();
 
     let dango_client = HttpClient::new(HTTPD_URL)?;
-    let app_cfg: AppConfig = dango_client.query_app_config(None).await?;
+    let app_cfg: AppConfig = dango_client.query_app_config().await?;
 
     let dango_chain_signer_address = SingleSigner::new_first_account(
         &dango_client,
@@ -80,8 +80,8 @@ async fn run_dango_validator() -> anyhow::Result<()> {
     build_agents();
 
     let dango_client = HttpClient::new(HTTPD_URL)?;
-    let chain_id = dango_client.query_status(None).await?.chain_id;
-    let app_cfg: AppConfig = dango_client.query_app_config(None).await?;
+    let chain_id = dango_client.query_status().await?.chain_id;
+    let app_cfg: AppConfig = dango_client.query_app_config().await?;
     let path = workspace().join("val-1");
 
     let dango_chain_signer_address = SingleSigner::new_first_account(

--- a/rust/main/chains/hyperlane-dango/tests/utils/agents/agent.rs
+++ b/rust/main/chains/hyperlane-dango/tests/utils/agents/agent.rs
@@ -1,7 +1,7 @@
 use {
     crate::utils::{AgentArgs, Args, ChainSettings, Launcher},
     cargo_metadata::MetadataCommand,
-    grug::btree_map,
+    dango_primitives::btree_map,
     std::{
         collections::{BTreeMap, BTreeSet},
         fs::{self, File},

--- a/rust/main/chains/hyperlane-dango/tests/utils/agents/chains_settings/base.rs
+++ b/rust/main/chains/hyperlane-dango/tests/utils/agents/chains_settings/base.rs
@@ -1,6 +1,6 @@
 use {
     crate::utils::{agents::traits::Args, dango_helper::IntoSignerConf},
-    grug::btree_map,
+    dango_primitives::btree_map,
     hyperlane_base::settings::SignerConf,
     std::collections::BTreeMap,
 };

--- a/rust/main/chains/hyperlane-dango/tests/utils/agents/chains_settings/dango.rs
+++ b/rust/main/chains/hyperlane-dango/tests/utils/agents/chains_settings/dango.rs
@@ -1,8 +1,8 @@
 use {
     crate::utils::{agents::traits::Args, ChainSettings},
+    dango_primitives::{btree_map, JsonSerExt},
     dango_types::config::AppConfig,
     ethers::types::H160,
-    grug::{btree_map, JsonSerExt},
     std::collections::BTreeMap,
 };
 

--- a/rust/main/chains/hyperlane-dango/tests/utils/agents/relayer.rs
+++ b/rust/main/chains/hyperlane-dango/tests/utils/agents/relayer.rs
@@ -1,6 +1,6 @@
 use {
     crate::utils::{AgentArgs, Args, Launcher},
-    grug::btree_map,
+    dango_primitives::btree_map,
     std::collections::{BTreeMap, BTreeSet},
 };
 

--- a/rust/main/chains/hyperlane-dango/tests/utils/agents/validator.rs
+++ b/rust/main/chains/hyperlane-dango/tests/utils/agents/validator.rs
@@ -1,6 +1,6 @@
 use {
     crate::utils::{AgentArgs, Args, Launcher, Location},
-    grug::btree_map,
+    dango_primitives::btree_map,
     hyperlane_core::H256,
     std::{
         collections::{BTreeMap, BTreeSet},

--- a/rust/main/chains/hyperlane-dango/tests/utils/crypto.rs
+++ b/rust/main/chains/hyperlane-dango/tests/utils/crypto.rs
@@ -1,5 +1,5 @@
 use {
-    grug::{HashExt, HexByteArray},
+    dango_primitives::{HashExt, HexByteArray},
     hyperlane_core::H256,
     k256::{ecdsa::SigningKey, elliptic_curve::rand_core::OsRng},
 };

--- a/rust/main/chains/hyperlane-dango/tests/utils/dango_builder.rs
+++ b/rust/main/chains/hyperlane-dango/tests/utils/dango_builder.rs
@@ -1,9 +1,9 @@
 use {
     crate::utils::{dango_helper::ChainHelper, get_free_port, try_for},
     dango_genesis::GenesisOption,
+    dango_primitives::{ClientWrapper, QueryClientExt},
     dango_sdk::HttpClient,
     dango_testing::{BlockCreation, Preset, TestOption},
-    grug::{ClientWrapper, QueryClientExt},
     std::{
         sync::{Arc, Mutex},
         thread,
@@ -15,7 +15,7 @@ pub struct DangoBuilder {
     chain_id: String,
     hyperlane_domain: u32,
     block_creation: BlockCreation,
-    block_time: grug::Duration,
+    block_time: dango_primitives::Duration,
     port: Option<u16>,
     genesis_option: Option<GenesisOption>,
 }
@@ -37,7 +37,7 @@ impl DangoBuilder {
         self
     }
 
-    pub fn with_block_time(mut self, block_time: grug::Duration) -> Self {
+    pub fn with_block_time(mut self, block_time: dango_primitives::Duration) -> Self {
         self.block_time = block_time;
         self
     }
@@ -106,7 +106,7 @@ impl DangoBuilder {
         try_for(
             Duration::from_secs(10),
             Duration::from_millis(500),
-            || async { client.query_status(None).await },
+            || async { client.query_status().await },
         )
         .await?;
 

--- a/rust/main/chains/hyperlane-dango/tests/utils/dango_helper.rs
+++ b/rust/main/chains/hyperlane-dango/tests/utils/dango_helper.rs
@@ -1,14 +1,14 @@
 use {
     async_trait::async_trait,
     dango_hyperlane_types::isms,
+    dango_primitives::{
+        btree_set, Addr, BroadcastClientExt, ClientWrapper, Coin, Coins, GasOption, HexByteArray,
+        Message, QueryClientExt, SearchTxClient, SearchTxOutcome, Signer,
+    },
     dango_testing::{TestAccount, TestAccounts},
     dango_types::{
         config::AppConfig,
         gateway::{self, Origin, Remote},
-    },
-    grug::{
-        btree_set, Addr, BroadcastClientExt, ClientWrapper, Coin, Coins, GasOption, HexByteArray,
-        Message, QueryClientExt, SearchTxClient, SearchTxOutcome, Signer,
     },
     hyperlane_base::settings::SignerConf,
     std::{collections::BTreeSet, time::Duration},
@@ -36,7 +36,7 @@ impl ChainHelper {
         hyperlane_domain: u32,
         httpd_urls: Vec<String>,
     ) -> anyhow::Result<Self> {
-        let cfg = client.query_app_config(None).await?;
+        let cfg = client.query_app_config().await?;
 
         Ok(Self {
             cfg,

--- a/rust/main/chains/hyperlane-dango/tests/utils/ext.rs
+++ b/rust/main/chains/hyperlane-dango/tests/utils/ext.rs
@@ -1,12 +1,12 @@
 use {
     async_trait::async_trait,
+    dango_primitives::{Defined, QueryClient, QueryClientExt, Undefined},
     dango_sdk::{Secret, SingleSigner},
     dango_types::{
         account_factory::{self, UserIndex, UserIndexOrName},
         auth::Nonce,
         config::AppConfig,
     },
-    grug::{Defined, QueryClient, QueryClientExt, Undefined},
 };
 
 #[async_trait]
@@ -41,7 +41,7 @@ where
             Some(cfg) => cfg.addresses.account_factory,
             None => {
                 client
-                    .query_app_config::<AppConfig>(None)
+                    .query_app_config::<AppConfig>()
                     .await?
                     .addresses
                     .account_factory
@@ -56,7 +56,6 @@ where
                     start_after: None,
                     limit: None,
                 },
-                None,
             )
             .await?
             .first()
@@ -67,7 +66,6 @@ where
             .query_wasm_smart(
                 factory_addr,
                 account_factory::QueryUserRequest(UserIndexOrName::Index(user_index)),
-                None,
             )
             .await?
             .accounts

--- a/rust/main/chains/hyperlane-dango/tests/utils/startup.rs
+++ b/rust/main/chains/hyperlane-dango/tests/utils/startup.rs
@@ -3,9 +3,9 @@ use {
         dango_helper::ChainHelper, get_free_port, Agent, CheckpointSyncer, DangoBuilder,
         DangoSettings, HexKey, Location, Relayer, Validator, ValidatorSigner,
     },
+    dango_primitives::{HexByteArray, ResultExt},
     dango_types::gateway::Origin,
     futures_util::try_join,
-    grug::{HexByteArray, ResultExt},
     std::collections::BTreeSet,
 };
 

--- a/rust/main/hyperlane-base/Cargo.toml
+++ b/rust/main/hyperlane-base/Cargo.toml
@@ -17,6 +17,8 @@ color-eyre = { workspace = true, optional = true }
 config.workspace = true
 console-subscriber.workspace = true
 convert_case.workspace = true
+dango-primitives.workspace = true
+dango-types.workspace = true
 dashmap.workspace = true
 derive-new.workspace = true
 derive_builder.workspace = true
@@ -64,14 +66,11 @@ hyperlane-aleo = { path = "../chains/hyperlane-aleo", optional = true }
 hyperlane-ethereum = { path = "../chains/hyperlane-ethereum" }
 hyperlane-fuel = { path = "../chains/hyperlane-fuel" }
 hyperlane-cosmos = { path = "../chains/hyperlane-cosmos" }
+hyperlane-dango = { path = "../chains/hyperlane-dango" }
 hyperlane-starknet = { path = "../chains/hyperlane-starknet" }
 hyperlane-sealevel = { path = "../chains/hyperlane-sealevel" }
 hyperlane-radix = { path = "../chains/hyperlane-radix" }
-hyperlane-dango= { path = "../chains/hyperlane-dango" }
 hyperlane-tron = { path = "../chains/hyperlane-tron" }
-
-grug.workspace = true
-dango-types.workspace = true
 
 # dependency version is determined by etheres
 rusoto_core = "*"

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -302,7 +302,7 @@ fn build_dango_connection_conf(
     let gas_price = chain
         .chain(&mut local_err)
         .get_key("gas_price")
-        .parse_value::<grug::Coin>("fails to deserialize grug::Coin")
+        .parse_value::<dango_primitives::Coin>("fails to deserialize dango_primitives::Coin")
         .end();
 
     let gas_scale = chain

--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -527,13 +527,13 @@ fn parse_signer(signer: ValueParser) -> ConfigResult<SignerConf> {
             let key = signer
                 .chain(&mut err)
                 .get_key("key")
-                .parse_value::<grug::HexByteArray<32>>("fail deserialize dango key")
+                .parse_value::<dango_primitives::HexByteArray<32>>("fail deserialize dango key")
                 .end();
 
             let address = signer
                 .chain(&mut err)
                 .get_key("address")
-                .parse_value::<grug::Addr>("fail deserialize dango address")
+                .parse_value::<dango_primitives::Addr>("fail deserialize dango address")
                 .end();
 
             err.into_result(SignerConf::Dango {

--- a/rust/main/hyperlane-base/src/settings/signers.rs
+++ b/rust/main/hyperlane-base/src/settings/signers.rs
@@ -1,11 +1,11 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
+use dango_primitives::{Addr, HexByteArray, Inner};
 use ethers::core::k256::sha2::{Digest, Sha256};
 use ethers::prelude::{AwsSigner, LocalWallet};
 use ethers::utils::hex::ToHex;
 use eyre::{bail, Context, Report};
-use grug::{Addr, HexByteArray, Inner};
 use hyperlane_dango::DangoConvertor;
 use rusoto_core::Region;
 use rusoto_kms::KmsClient;

--- a/rust/main/hyperlane-core/Cargo.toml
+++ b/rust/main/hyperlane-core/Cargo.toml
@@ -21,6 +21,7 @@ bech32.workspace = true
 bytes = { workspace = true, features = ["serde"] }
 config = { workspace = true, optional = true }
 convert_case.workspace = true
+dango-primitives = { workspace = true }
 derive-new.workspace = true
 derive_more.workspace = true
 ethers-contract = { workspace = true, optional = true }
@@ -30,7 +31,6 @@ eyre.workspace = true
 fixed-hash.workspace = true
 futures = { workspace = true, optional = true }
 getrandom.workspace = true
-grug = { workspace = true}
 hex.workspace = true
 regex = { workspace = true, optional = true }
 itertools.workspace = true

--- a/rust/main/hyperlane-core/src/error.rs
+++ b/rust/main/hyperlane-core/src/error.rs
@@ -171,13 +171,13 @@ pub enum ChainCommunicationError {
     SimulationFailed(String),
     /// Dango error
     #[error(transparent)]
-    DangoError(#[from] grug::StdError),
+    DangoError(#[from] dango_primitives::StdError),
     /// Anyhow error
     #[error(transparent)]
     AnyhowError(#[from] anyhow::Error),
     /// Grug error
     #[error(transparent)]
-    GrugGasEstimateError(#[from] grug::GasEstimateError),
+    GrugGasEstimateError(#[from] dango_primitives::GasEstimateError),
 }
 
 impl ChainCommunicationError {


### PR DESCRIPTION
Adopt the upstream crate renames, using the real names in code instead of aliases: grug -> dango-primitives, grug-math -> dango-math, hyperlane-types -> dango-hyperlane-types. Drop grug-app and grug-jmt, which nothing used.

Adapt to the new QueryClient API: state queries are no longer height-pinned (every call site already passed None, so this is a no-op) and query_store was removed (it had no callers).

tracing moves 0.1.41 -> 0.1.44 (required by the new dependency tree via clickhouse), which requires event levels to live for 'static; hoist the relayer's dynamic status-log level into a const.